### PR TITLE
SDK-710: Add Parent Remember Me ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
 ## API Coverage
 
 * Activity Details
-  * [X] User ID `user_id`
+  * [X] Remember Me ID `remember_me_id`
+  * [X] Parent Remember Me ID `parent_remember_me_id`
   * [X] Base64 Selfie URI `base64_selfie_uri`
   * [X] Age verified `age_verified`
   * [X] Profile `profile`

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -6,8 +6,15 @@ module Yoti
     # @return [String] the outcome of the profile request, eg: SUCCESS
     attr_reader :outcome
 
+    # @deprecated replaced by :remember_me_id
     # @return [String] the Yoti ID
     attr_reader :user_id
+
+    # @return [String] the Remember Me ID
+    attr_reader :remember_me_id
+
+    # @return [String] the Parent Remember Me ID
+    attr_reader :parent_remember_me_id
 
     # @return [Hash] the decoded profile attributes
     attr_reader :user_profile
@@ -44,7 +51,10 @@ module Yoti
         end
       end
 
-      @user_id = receipt['remember_me_id']
+      @remember_me_id = receipt['remember_me_id']
+      @user_id = @remember_me_id
+      @parent_remember_me_id = receipt['parent_remember_me_id']
+
       @outcome = receipt['sharing_outcome']
     end
 

--- a/spec/sample-data/responses/profile.json
+++ b/spec/sample-data/responses/profile.json
@@ -10,6 +10,7 @@
       "policy_uri":"lNVPUiMEAf9oUBc56Tn_mZcbp4eOyXOd6mPTO_uYe8kKtZEgQFRekJrparpy8WHR",
       "personal_key":"t7es00YGJZgU2Wxoo3OqcJAdI8BSgKA134G1NGBK5xY=",
       "remember_me_id":"Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU",
+      "parent_remember_me_id":"f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8",
       "sharing_outcome":"SUCCESS",
       "timestamp":"2016-07-19T08:55:38Z"
    }

--- a/spec/yoti/activity_details_spec.rb
+++ b/spec/yoti/activity_details_spec.rb
@@ -1,13 +1,38 @@
 require 'spec_helper'
 
-describe 'Yoti::ActivityDetails' do
-  let(:receipt) { { 'remember_me_id' => '123qweasd', 'sharing_outcome' => 'SUCCESS' } }
-  let(:activity_details) { Yoti::ActivityDetails.new(receipt) }
+def activity_details
+  profile_json = JSON.parse(File.read('spec/sample-data/responses/profile.json'))
+  receipt = profile_json['receipt']
+  encrypted_data = Yoti::Protobuf.current_user(receipt)
+  unwrapped_key = Yoti::SSL.decrypt_token(receipt['wrapped_receipt_key'])
+  decrypted_data = Yoti::SSL.decipher(unwrapped_key, encrypted_data.iv, encrypted_data.cipher_text)
+  decrypted_profile = Yoti::Protobuf.attribute_list(decrypted_data)
+  Yoti::ActivityDetails.new(receipt, decrypted_profile)
+end
 
+describe 'Yoti::ActivityDetails' do
   describe '#initialize' do
     it 'sets the instance variables' do
-      expect(activity_details.user_id).to eql('123qweasd')
+      remember_me_id = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU'
+      expect(activity_details.user_id).to eql(remember_me_id)
+      expect(activity_details.remember_me_id).to eql(remember_me_id)
+      expect(activity_details.parent_remember_me_id).to eql('f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8')
       expect(activity_details.outcome).to eql('SUCCESS')
+    end
+  end
+
+  describe '#profile' do
+    it 'returns the Yoti::Profile with processed attributes' do
+      expect(activity_details.profile).to be_an_instance_of(Yoti::Profile)
+      expect(activity_details.profile.selfie).to be_an_instance_of(Yoti::Attribute)
+      expect(activity_details.profile.phone_number).to be_an_instance_of(Yoti::Attribute)
+      expect(activity_details.profile.phone_number.value).to eql('+447474747474')
+    end
+  end
+
+  describe '#structured_postal_address' do
+    it 'returns structured_postal_address' do
+      expect(activity_details.structured_postal_address).to eql(nil)
     end
   end
 end


### PR DESCRIPTION
- Added `Yoti::ActivityDetails.parent_remember_me_id`
- Added `Yoti::ActivityDetails.remember_me_id`
- Deprecated `Yoti::ActivityDetails::user_id `
- Updated README
- Added extra `Yoti::ActivityDetails` test coverage from #30 which uses the sample data `profile.json` (to check that profile is processed correctly)
