### PR TITLE
SDK-582: Return formatted address as attribute

### DIFF
--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -64,10 +64,11 @@ module Yoti
     end
 
     def process_attribute(attribute)
-      @user_profile[attribute.name] = Yoti::Protobuf.value_based_on_content_type(attribute.value, attribute.content_type)
+      attr_value = Yoti::Protobuf.value_based_on_content_type(attribute.value, attribute.content_type)
+      @user_profile[attribute.name] = attr_value
       anchor_processor = Yoti::AnchorProcessor.new(attribute.anchors)
       anchors_list = anchor_processor.process
-      @extended_profile[attribute.name] = Yoti::Attribute.new(attribute.name, attribute.value, anchors_list['sources'], anchors_list['verifiers'])
+      @extended_profile[attribute.name] = Yoti::Attribute.new(attribute.name, attr_value, anchors_list['sources'], anchors_list['verifiers'])
     end
   end
 end

--- a/lib/yoti/data_type/profile.rb
+++ b/lib/yoti/data_type/profile.rb
@@ -46,7 +46,7 @@ module Yoti
       postal_address = get_attribute(Yoti::Attribute::POSTAL_ADDRESS)
       return postal_address unless postal_address.nil?
 
-      formatted_address
+      attribute_from_formatted_address
     end
 
     def structured_postal_address
@@ -62,10 +62,16 @@ module Yoti
 
     protected
 
-    def formatted_address
+    def attribute_from_formatted_address
       return nil if structured_postal_address.nil?
+      return nil unless structured_postal_address.value.key?('formatted_address')
 
-      structured_postal_address['formatted_address'] if structured_postal_address.key?('formatted_address')
+      Yoti::Attribute.new(
+        Yoti::Attribute::POSTAL_ADDRESS,
+        structured_postal_address.value['formatted_address'],
+        structured_postal_address.sources,
+        structured_postal_address.verifiers
+      )
     end
   end
 end

--- a/spec/yoti/activity_details_spec.rb
+++ b/spec/yoti/activity_details_spec.rb
@@ -1,22 +1,45 @@
 require 'spec_helper'
 
 def activity_details
-  profile_json = JSON.parse(File.read('spec/sample-data/responses/profile.json'))
-  receipt = profile_json['receipt']
-  encrypted_data = Yoti::Protobuf.current_user(receipt)
-  unwrapped_key = Yoti::SSL.decrypt_token(receipt['wrapped_receipt_key'])
-  decrypted_data = Yoti::SSL.decipher(unwrapped_key, encrypted_data.iv, encrypted_data.cipher_text)
-  decrypted_profile = Yoti::Protobuf.attribute_list(decrypted_data)
-  Yoti::ActivityDetails.new(receipt, decrypted_profile)
+  Yoti::ActivityDetails.new(
+    {
+      'remember_me_id' => 'test_remember_me_id',
+      'parent_remember_me_id' => 'test_parent_remember_me_id',
+      'sharing_outcome' => 'SUCCESS'
+    },
+    proto_attr_list(
+      [
+        proto_attr('selfie', 'test_selfie_value', :STRING),
+        proto_attr('phone_number', '+447474747474', :STRING),
+        proto_attr('test_integer', '123', :INT),
+        proto_attr('structured_postal_address', '{"formatted_address":"test_structured_address"}', :JSON)
+      ]
+    )
+  )
+end
+
+def proto_attr_list(attr_arr)
+  attr_list = Yoti::Protobuf::Attrpubapi::AttributeList.new
+  attr_arr.each do |attr|
+    attr_list.attributes.push(attr)
+  end
+  attr_list
+end
+
+def proto_attr(name, value, content_type)
+  attr = Yoti::Protobuf::Attrpubapi::Attribute.new
+  attr.name = name
+  attr.value = value
+  attr.content_type = content_type
+  attr
 end
 
 describe 'Yoti::ActivityDetails' do
   describe '#initialize' do
     it 'sets the instance variables' do
-      remember_me_id = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU'
-      expect(activity_details.user_id).to eql(remember_me_id)
-      expect(activity_details.remember_me_id).to eql(remember_me_id)
-      expect(activity_details.parent_remember_me_id).to eql('f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8')
+      expect(activity_details.user_id).to eql('test_remember_me_id')
+      expect(activity_details.remember_me_id).to eql('test_remember_me_id')
+      expect(activity_details.parent_remember_me_id).to eql('test_parent_remember_me_id')
       expect(activity_details.outcome).to eql('SUCCESS')
     end
   end
@@ -24,15 +47,24 @@ describe 'Yoti::ActivityDetails' do
   describe '#profile' do
     it 'returns the Yoti::Profile with processed attributes' do
       expect(activity_details.profile).to be_an_instance_of(Yoti::Profile)
+
       expect(activity_details.profile.selfie).to be_an_instance_of(Yoti::Attribute)
+      expect(activity_details.profile.selfie.value).to eql('test_selfie_value')
+
       expect(activity_details.profile.phone_number).to be_an_instance_of(Yoti::Attribute)
       expect(activity_details.profile.phone_number.value).to eql('+447474747474')
+
+      expect(activity_details.profile.structured_postal_address).to be_an_instance_of(Yoti::Attribute)
+      expect(activity_details.profile.structured_postal_address.value['formatted_address']).to eql('test_structured_address')
+
+      expect(activity_details.profile.get_attribute('test_integer')).to be_an_instance_of(Yoti::Attribute)
+      expect(activity_details.profile.get_attribute('test_integer').value).to eql(123)
     end
   end
 
   describe '#structured_postal_address' do
     it 'returns structured_postal_address' do
-      expect(activity_details.structured_postal_address).to eql(nil)
+      expect(activity_details.structured_postal_address['formatted_address']).to eql('test_structured_address')
     end
   end
 end

--- a/spec/yoti/data_type/profile_spec.rb
+++ b/spec/yoti/data_type/profile_spec.rb
@@ -72,8 +72,21 @@ describe 'Yoti::Profile' do
       expect(profile.postal_address).to eql('test_postal_address')
     end
     it 'should return formatted address when postal address not available' do
-      formatted_address_profile = Yoti::Profile.new(Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS => { 'formatted_address' => 'test_structured_address' })
-      expect(formatted_address_profile.postal_address).to eql('test_structured_address')
+      structured_address_attribute = Yoti::Attribute.new(
+        Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS,
+        { 'formatted_address' => 'test_structured_address' },
+        'test_sources',
+        'test_verifiers'
+      )
+
+      formatted_address_profile = Yoti::Profile.new(
+        Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS => structured_address_attribute
+      )
+
+      expect(formatted_address_profile.postal_address.name).to eql(Yoti::Attribute::POSTAL_ADDRESS)
+      expect(formatted_address_profile.postal_address.sources).to eql('test_sources')
+      expect(formatted_address_profile.postal_address.verifiers).to eql('test_verifiers')
+      expect(formatted_address_profile.postal_address.value).to eql('test_structured_address')
     end
   end
 


### PR DESCRIPTION
- `Yoti::Profile#postal_address` will return _Attribute_ with formatted address as value when postal address isn't available
_(fixes bug that was causing the original JSON string to be returned)_
- Attribute values are now being processed
_(fixes bug that was causing original values to be returned for all Attributes)_