### PR TITLE
SDK-898: Return undefined and unknown content types as string

### DIFF
--- a/lib/yoti.rb
+++ b/lib/yoti.rb
@@ -18,6 +18,7 @@ require_relative 'yoti/data_type/signed_time_stamp'
 
 require_relative 'yoti/util/age_processor'
 require_relative 'yoti/util/anchor_processor'
+require_relative 'yoti/util/log.rb'
 
 require_relative 'yoti/activity_details'
 require_relative 'yoti/client'

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -56,7 +56,11 @@ module Yoti
       return nil unless @decrypted_profile.respond_to?(:attributes)
 
       @decrypted_profile.attributes.each do |attribute|
-        process_attribute(attribute)
+        begin
+          process_attribute(attribute)
+        rescue StandardError => e
+          Yoti::Log.logger.warn("#{e.message} (Attribute: #{attribute.name})")
+        end
 
         @base64_selfie_uri = Yoti::Protobuf.image_uri_based_on_content_type(attribute.value, attribute.content_type) if attribute.name == 'selfie'
         @age_verified = attribute.value == 'true' if Yoti::AgeProcessor.is_age_verification(attribute.name)

--- a/lib/yoti/protobuf/main.rb
+++ b/lib/yoti/protobuf/main.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('./attrpubapi/', __dir__)
 
 require 'google/protobuf'
 require 'json'
+require 'logger'
 
 require_relative 'attrpubapi/List_pb.rb'
 require_relative 'compubapi/EncryptedData_pb.rb'
@@ -18,6 +19,10 @@ module Yoti
       CT_JSON = :JSON # json_string
       CT_INT = :INT # integer
 
+      def logger
+        @logger ||= Logger.new(STDOUT)
+      end
+
       def current_user(receipt)
         return nil unless valid_receipt?(receipt)
 
@@ -32,16 +37,17 @@ module Yoti
 
       def value_based_on_content_type(value, content_type = nil)
         case content_type
-        when CT_UNDEFINED
-          raise ProtobufError, 'The content type is invalid.'
         when CT_STRING, CT_DATE
           value.encode('utf-8')
         when CT_JSON
           JSON.parse(value)
         when CT_INT
           value.to_i
-        else
+        when CT_JPEG, CT_PNG
           value
+        else
+          logger.warn("Unknown Content Type '#{content_type}', parsing as a String")
+          value.encode('utf-8')
         end
       end
 

--- a/lib/yoti/protobuf/main.rb
+++ b/lib/yoti/protobuf/main.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.unshift File.expand_path('./attrpubapi/', __dir__)
 
 require 'google/protobuf'
 require 'json'
-require 'logger'
 
 require_relative 'attrpubapi/List_pb.rb'
 require_relative 'compubapi/EncryptedData_pb.rb'
@@ -18,10 +17,6 @@ module Yoti
       CT_PNG = :PNG # standard .png image
       CT_JSON = :JSON # json_string
       CT_INT = :INT # integer
-
-      def logger
-        @logger ||= Logger.new(STDOUT)
-      end
 
       def current_user(receipt)
         return nil unless valid_receipt?(receipt)
@@ -46,7 +41,7 @@ module Yoti
         when CT_JPEG, CT_PNG
           value
         else
-          logger.warn("Unknown Content Type '#{content_type}', parsing as a String")
+          Yoti::Log.logger.warn("Unknown Content Type '#{content_type}', parsing as a String")
           value.encode('utf-8')
         end
       end

--- a/lib/yoti/util/log.rb
+++ b/lib/yoti/util/log.rb
@@ -1,0 +1,11 @@
+require 'logger'
+
+module Yoti
+  module Log
+    class << self
+      def logger
+        @logger ||= Logger.new(STDOUT)
+      end
+    end
+  end
+end

--- a/lib/yoti/util/log.rb
+++ b/lib/yoti/util/log.rb
@@ -4,7 +4,17 @@ module Yoti
   module Log
     class << self
       def logger
-        @logger ||= Logger.new(STDOUT)
+        @logger || create_logger(STDOUT)
+      end
+
+      def output(output_stream)
+        create_logger(output_stream)
+      end
+
+      private
+
+      def create_logger(output_stream)
+        @logger = Logger.new(output_stream)
       end
     end
   end

--- a/lib/yoti/util/log.rb
+++ b/lib/yoti/util/log.rb
@@ -15,6 +15,8 @@ module Yoti
 
       def create_logger(output_stream)
         @logger = Logger.new(output_stream)
+        @logger.progname = 'Yoti'
+        @logger
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,10 @@ RSpec.configure do |config|
     stub_api_requests_v1(:post, 'aml_check', 'aml-check')
   end
 
+  config.after(:each) do
+    Yoti::Log.output(STDOUT)
+  end
+
   config.before do
     initialize_test_app
   end

--- a/spec/yoti/protobuf/protobuf_spec.rb
+++ b/spec/yoti/protobuf/protobuf_spec.rb
@@ -59,7 +59,7 @@ describe 'Yoti::Protobuf' do
 
       it 'returns the value' do
         is_expected.to eql(value)
-        expect(@log_output.string).to include "Unknown Content Type 'UNDEFINED', parsing as a String"
+        expect(@log_output.string).to include "WARN -- Yoti: Unknown Content Type 'UNDEFINED', parsing as a String"
       end
     end
 
@@ -111,7 +111,7 @@ describe 'Yoti::Protobuf' do
 
       it 'returns the value' do
         is_expected.to eql(value)
-        expect(@log_output.string).to include "Unknown Content Type '100', parsing as a String"
+        expect(@log_output.string).to include "WARN -- Yoti: Unknown Content Type '100', parsing as a String"
       end
     end
   end

--- a/spec/yoti/protobuf/protobuf_spec.rb
+++ b/spec/yoti/protobuf/protobuf_spec.rb
@@ -52,8 +52,14 @@ describe 'Yoti::Protobuf' do
     context 'when the content type is UNDEFINED' do
       let(:content_type) { :UNDEFINED }
 
+      before(:each) do
+        @log_output = StringIO.new
+        Yoti::Log.output(@log_output)
+      end
+
       it 'returns the value' do
         is_expected.to eql(value)
+        expect(@log_output.string).to include "Unknown Content Type 'UNDEFINED', parsing as a String"
       end
     end
 
@@ -98,8 +104,14 @@ describe 'Yoti::Protobuf' do
     context 'when the content type is something else' do
       let(:content_type) { 100 }
 
+      before(:each) do
+        @log_output = StringIO.new
+        Yoti::Log.output(@log_output)
+      end
+
       it 'returns the value' do
         is_expected.to eql(value)
+        expect(@log_output.string).to include "Unknown Content Type '100', parsing as a String"
       end
     end
   end

--- a/spec/yoti/protobuf/protobuf_spec.rb
+++ b/spec/yoti/protobuf/protobuf_spec.rb
@@ -52,9 +52,8 @@ describe 'Yoti::Protobuf' do
     context 'when the content type is UNDEFINED' do
       let(:content_type) { :UNDEFINED }
 
-      it 'raises a ProtobufError' do
-        error = 'The content type is invalid.'
-        expect { subject }.to raise_error(Yoti::ProtobufError, error)
+      it 'returns the value' do
+        is_expected.to eql(value)
       end
     end
 
@@ -97,7 +96,7 @@ describe 'Yoti::Protobuf' do
     end
 
     context 'when the content type is something else' do
-      let(:content_type) { double }
+      let(:content_type) { 100 }
 
       it 'returns the value' do
         is_expected.to eql(value)


### PR DESCRIPTION
- Returning undefined and unknown content types as string
- Logging message when an unknown/undefined content type is parsed as string