### PR TITLE
SDK-593: Coding standards

### DIFF
--- a/lib/yoti/ssl.rb
+++ b/lib/yoti/ssl.rb
@@ -26,8 +26,8 @@ module Yoti
 
         begin
           private_key.private_decrypt(Base64.urlsafe_decode64(encrypted_connect_token))
-        rescue StandardError => error
-          raise SslError, "Could not decrypt token. #{error}"
+        rescue StandardError => e
+          raise SslError, "Could not decrypt token. #{e}"
         end
       end
 
@@ -63,8 +63,8 @@ module Yoti
 
       def private_key
         @private_key ||= OpenSSL::PKey::RSA.new(pem)
-      rescue StandardError => error
-        raise SslError, "The secure key is invalid. #{error}"
+      rescue StandardError => e
+        raise SslError, "The secure key is invalid. #{e}"
       end
     end
   end


### PR DESCRIPTION
- Fixes cop check introduced in [0.67.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) _Add new Naming/RescuedExceptionsVariableName cop_
- Fixes build failure for #34 