### PR TITLE
SDK-912: Include rubocop-performance gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'guard-rspec'
 gem 'pry'
 gem 'pry-byebug'
 gem 'rubocop'
+gem 'rubocop-performance'
 
 gemspec


### PR DESCRIPTION
Addresses warning:
> Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.