### PR TITLE
SDK-1016: ActivityDetails getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
 * Activity Details
   * [X] Remember Me ID `remember_me_id`
   * [X] Parent Remember Me ID `parent_remember_me_id`
+  * [X] Receipt ID `receipt_id`
   * [X] Base64 Selfie URI `base64_selfie_uri`
   * [X] Age verified `age_verified`
   * [X] Profile `profile`

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
   * [X] Remember Me ID `remember_me_id`
   * [X] Parent Remember Me ID `parent_remember_me_id`
   * [X] Receipt ID `receipt_id`
+  * [X] Timestamp `timestamp`
   * [X] Base64 Selfie URI `base64_selfie_uri`
   * [X] Age verified `age_verified`
   * [X] Profile `profile`

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -25,13 +25,21 @@ module Yoti
     # @return [Boolean] the age under/over attribute
     attr_reader :age_verified
 
+    # @return [String] Receipt ID identifying a completed activity
+    attr_reader :receipt_id
+
+    # @return [String] Time and date of the sharing activity
+    attr_reader :timestamp
+
     # @param receipt [Hash] the receipt from the API request
     # @param decrypted_profile [Object] Protobuf AttributeList decrypted object containing the profile attributes
     def initialize(receipt, decrypted_profile = nil)
       @remember_me_id = receipt['remember_me_id']
       @user_id = @remember_me_id
+      @receipt_id = receipt['receipt_id']
       @parent_remember_me_id = receipt['parent_remember_me_id']
       @outcome = receipt['sharing_outcome']
+      @timestamp = receipt['timestamp'] ? Time.parse(receipt['timestamp']) : nil
       @user_profile = {}
       @extended_profile = {}
       process_decrypted_profile(decrypted_profile)

--- a/spec/yoti/activity_details_spec.rb
+++ b/spec/yoti/activity_details_spec.rb
@@ -29,7 +29,8 @@ describe 'Yoti::ActivityDetails' do
       receipt = {
         'remember_me_id' => 'test_remember_me_id',
         'parent_remember_me_id' => 'test_parent_remember_me_id',
-        'sharing_outcome' => 'SUCCESS'
+        'sharing_outcome' => 'SUCCESS',
+        'timestamp' => '2016-07-19T08:55:38Z'
       }
       activity_details = activity_details(receipt, [])
 
@@ -37,6 +38,21 @@ describe 'Yoti::ActivityDetails' do
       expect(activity_details.remember_me_id).to eql('test_remember_me_id')
       expect(activity_details.parent_remember_me_id).to eql('test_parent_remember_me_id')
       expect(activity_details.outcome).to eql('SUCCESS')
+      expect(activity_details.timestamp).to be_an_instance_of(Time)
+      expect(activity_details.timestamp.to_s).to eql('2016-07-19 08:55:38 UTC')
+    end
+  end
+
+  describe '#timestamp' do
+    context 'when timestamp has microseconds' do
+      it 'returns microseconds' do
+        receipt = {
+          'timestamp' => '2016-07-19T08:55:38.123456Z'
+        }
+        activity_details = activity_details(receipt, [])
+
+        expect(activity_details.timestamp.strftime('%F %H:%M:%S.%6N')).to eql('2016-07-19 08:55:38.123456')
+      end
     end
   end
 

--- a/spec/yoti/client_spec.rb
+++ b/spec/yoti/client_spec.rb
@@ -6,7 +6,10 @@ describe 'Yoti::Client' do
     let(:profile) { activity_details.user_profile }
     let(:outcome) { activity_details.outcome }
     let(:user_id) { activity_details.user_id }
+    let(:remember_me_id) { activity_details.remember_me_id }
     let(:base64_selfie_uri) { activity_details.base64_selfie_uri }
+    let(:receipt_id) { activity_details.receipt_id }
+    let(:timestamp) { activity_details.timestamp }
 
     context 'when the encrypted token is nil', type: :api_with_profile do
       it 'raises an ArgumentError' do
@@ -34,9 +37,19 @@ describe 'Yoti::Client' do
         expect(profile).not_to be_nil
       end
 
-      it 'contains the decrypted user ID value' do
+      it 'contains the decrypted remember me ID value' do
         expected_id = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU'
+        expect(remember_me_id).to eql(expected_id)
         expect(user_id).to eql(expected_id)
+      end
+
+      it 'contains the receipt ID value' do
+        expect(receipt_id).to eql('9HNJDX5bEIN5TqBm0OGzVIc1LaAmbzfx6eIrwNdwpHvKeQmgPujyogC+r7hJCVPl')
+      end
+
+      it 'contains the timestamp value' do
+        expect(timestamp.to_s).to eql('2016-07-19 08:55:38 UTC')
+        expect(timestamp.zone).to eql('UTC')
       end
 
       it 'contains the decrypted phone number value' do


### PR DESCRIPTION
### Added
- `Yoti::ActivityDetails#receipt_id`
- `Yoti::ActivityDetails#timestamp`
