### PR TITLE
SDK-1017: Application Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
     * [X] Name `name`
     * [X] URL `url`
     * [X] Logo `logo`
-    * [X] Receipt Background Colour `receipt_bgcolor`
+    * [X] Receipt Background Color `receipt_bgcolor`
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
   * [X] Timestamp `timestamp`
   * [X] Base64 Selfie URI `base64_selfie_uri`
   * [X] Age verified `age_verified`
-  * [X] User Profile `profile`
+  * [X] Profile `profile`
     * [X] Selfie `selfie`
     * [X] Full Name `full_name`
     * [X] Given Names `given_names`

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
   * [X] Timestamp `timestamp`
   * [X] Base64 Selfie URI `base64_selfie_uri`
   * [X] Age verified `age_verified`
-  * [X] Profile `profile`
+  * [X] User Profile `profile`
     * [X] Selfie `selfie`
     * [X] Full Name `full_name`
     * [X] Given Names `given_names`
@@ -322,6 +322,11 @@ Visiting `https://localhost:4567/` should show a Yoti Connect button
     * [X] Address `postal_address`
     * [X] Gender `gender`
     * [X] Nationality `nationality`
+  * [X] Application Profile `application_profile`
+    * [X] Name `name`
+    * [X] URL `url`
+    * [X] Logo `logo`
+    * [X] Receipt Background Colour `receipt_bgcolor`
 
 ## Support
 

--- a/lib/yoti.rb
+++ b/lib/yoti.rb
@@ -12,6 +12,8 @@ require_relative 'yoti/http/profile_request'
 require_relative 'yoti/http/request'
 
 require_relative 'yoti/data_type/anchor'
+require_relative 'yoti/data_type/base_profile'
+require_relative 'yoti/data_type/application_profile'
 require_relative 'yoti/data_type/profile'
 require_relative 'yoti/data_type/attribute'
 require_relative 'yoti/data_type/signed_time_stamp'

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -42,6 +42,15 @@ module Yoti
     attr_reader :parent_remember_me_id
 
     #
+    # The decoded profile attributes
+    #
+    # @deprecated replaced by :profile
+    #
+    # @return [Hash]
+    #
+    attr_reader :user_profile
+
+    #
     # Base64 encoded selfie image
     #
     # @return [String]
@@ -82,6 +91,7 @@ module Yoti
       @timestamp = receipt['timestamp'] ? Time.parse(receipt['timestamp']) : nil
       @extended_user_profile = process_decrypted_profile(decrypted_profile)
       @extended_application_profile = process_decrypted_profile(decrypted_application_profile)
+      @user_profile = process_user_profile
     end
 
     #
@@ -112,23 +122,6 @@ module Yoti
     #
     def application_profile
       Yoti::ApplicationProfile.new(@extended_application_profile)
-    end
-
-    #
-    # The decoded profile attributes
-    #
-    # @deprecated replaced by :profile
-    #
-    # @return [Hash]
-    #
-    def user_profile
-      if @extended_user_profile.nil?
-        {}
-      else
-        @extended_user_profile.map do |name, attribute|
-          [name, attribute.value]
-        end.to_h
-      end
     end
 
     protected
@@ -165,6 +158,25 @@ module Yoti
 
     def process_age_verified(attribute)
       @age_verified = attribute.value == 'true' if Yoti::AgeProcessor.is_age_verification(attribute.name)
+    end
+
+    private
+
+    #
+    # Processes the extended user profile to user profile hash
+    #
+    # @deprecated :user_profile will be replaced by :profile
+    #
+    # @return [Hash]
+    #
+    def process_user_profile
+      if @extended_user_profile.nil?
+        {}
+      else
+        @extended_user_profile.map do |name, attribute|
+          [name, attribute.value]
+        end.to_h
+      end
     end
   end
 end

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -91,7 +91,9 @@ module Yoti
       @timestamp = receipt['timestamp'] ? Time.parse(receipt['timestamp']) : nil
       @extended_user_profile = process_decrypted_profile(decrypted_profile)
       @extended_application_profile = process_decrypted_profile(decrypted_application_profile)
-      @user_profile = process_user_profile
+      @user_profile = @extended_user_profile.map do |name, attribute|
+        [name, attribute.value]
+      end.to_h
     end
 
     #
@@ -180,25 +182,6 @@ module Yoti
     #
     def process_age_verified(attribute)
       @age_verified = attribute.value == 'true' if Yoti::AgeProcessor.is_age_verification(attribute.name)
-    end
-
-    private
-
-    #
-    # Processes the extended user profile to user profile hash
-    #
-    # @deprecated :user_profile will be replaced by :profile
-    #
-    # @return [Hash]
-    #
-    def process_user_profile
-      if @extended_user_profile.nil?
-        {}
-      else
-        @extended_user_profile.map do |name, attribute|
-          [name, attribute.value]
-        end.to_h
-      end
     end
   end
 end

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -154,7 +154,7 @@ module Yoti
     #
     # Converts protobuf attribute into Attribute
     #
-    # @param [Yoti::rotobuf::Attrpubapi::Attribute] attribute
+    # @param [Yoti::Protobuf::Attrpubapi::Attribute] attribute
     #
     # @return [Attribute, nil]
     #

--- a/lib/yoti/activity_details.rb
+++ b/lib/yoti/activity_details.rb
@@ -126,9 +126,16 @@ module Yoti
 
     protected
 
+    #
+    # Process the decrypted profile to into hash
+    #
+    # @param [Yoti::Protobuf::Attrpubapi::AttributeList] decrypted_profile
+    #
+    # @return [Hash]
+    #
     def process_decrypted_profile(decrypted_profile)
-      return nil unless decrypted_profile.is_a?(Object)
-      return nil unless decrypted_profile.respond_to?(:attributes)
+      return {} unless decrypted_profile.is_a?(Object)
+      return {} unless decrypted_profile.respond_to?(:attributes)
 
       profile_data = {}
       decrypted_profile.attributes.each do |attribute|
@@ -142,7 +149,17 @@ module Yoti
       profile_data
     end
 
+    #
+    # Converts protobuf attribute into Attribute
+    #
+    # @param [Yoti::rotobuf::Attrpubapi::Attribute] attribute
+    #
+    # @return [Attribute, nil]
+    #
     def process_attribute(attribute)
+      # Application Logo can be empty, return nil when this occurs.
+      return nil if attribute.name == Yoti::Attribute::APPLICATION_LOGO && attribute.value == ''
+
       attr_value = Yoti::Protobuf.value_based_on_content_type(attribute.value, attribute.content_type)
       attr_value = Yoti::Protobuf.value_based_on_attribute_name(attr_value, attribute.name)
 
@@ -156,6 +173,11 @@ module Yoti
       Yoti::Attribute.new(attribute.name, attr_value, anchors_list['sources'], anchors_list['verifiers'])
     end
 
+    #
+    # Processes age verification
+    #
+    # @param [Yoti::Protobuf::Attrpubapi::Attribute] attribute
+    #
     def process_age_verified(attribute)
       @age_verified = attribute.value == 'true' if Yoti::AgeProcessor.is_age_verification(attribute.name)
     end

--- a/lib/yoti/client.rb
+++ b/lib/yoti/client.rb
@@ -1,20 +1,24 @@
 module Yoti
+  #
   # Handles all the publicly accesible Yoti methods for
   # geting data using an encrypted connect token
+  #
   module Client
+    #
     # Performs all the steps required to get the decrypted profile from an API request
+    #
     # @param encrypted_connect_token [String] token provided as a base 64 string
+    #
     # @return [Object] an ActivityDetails instance encapsulating the user profile
+    #
     def self.get_activity_details(encrypted_connect_token)
       receipt = Yoti::ProfileRequest.new(encrypted_connect_token).receipt
-      encrypted_data = Protobuf.current_user(receipt)
+      user_profile = Protobuf.user_profile(receipt)
+      application_profile = Protobuf.application_profile(receipt)
 
-      return ActivityDetails.new(receipt) if encrypted_data.nil?
+      return ActivityDetails.new(receipt) if user_profile.nil?
 
-      unwrapped_key = Yoti::SSL.decrypt_token(receipt['wrapped_receipt_key'])
-      decrypted_data = Yoti::SSL.decipher(unwrapped_key, encrypted_data.iv, encrypted_data.cipher_text)
-      decrypted_profile = Protobuf.attribute_list(decrypted_data)
-      ActivityDetails.new(receipt, decrypted_profile)
+      ActivityDetails.new(receipt, user_profile, application_profile)
     end
 
     def self.aml_check(aml_profile)

--- a/lib/yoti/data_type/application_profile.rb
+++ b/lib/yoti/data_type/application_profile.rb
@@ -1,0 +1,43 @@
+module Yoti
+  #
+  # Profile of an application with convenience methods to access well-known attributes.
+  #
+  class ApplicationProfile < BaseProfile
+    #
+    # The name of the application.
+    #
+    # @return [Attribute, nil]
+    #
+    def name
+      get_attribute(Yoti::Attribute::APPLICATION_NAME)
+    end
+
+    #
+    # The URL where the application is available at.
+    #
+    # @return [Attribute, nil]
+    #
+    def url
+      get_attribute(Yoti::Attribute::APPLICATION_URL)
+    end
+
+    #
+    # The logo of the application that will be displayed to users that perform a share with it.
+    #
+    # @return [Attribute, nil]
+    #
+    def logo
+      get_attribute(Yoti::Attribute::APPLICATION_LOGO)
+    end
+
+    #
+    # The background colour that will be displayed on each receipt the user gets, as a result
+    # of a share with the application.
+    #
+    # @return [Attribute, nil]
+    #
+    def receipt_bgcolor
+      get_attribute(Yoti::Attribute::APPLICATION_RECEIPT_BGCOLOR)
+    end
+  end
+end

--- a/lib/yoti/data_type/application_profile.rb
+++ b/lib/yoti/data_type/application_profile.rb
@@ -31,7 +31,7 @@ module Yoti
     end
 
     #
-    # The background colour that will be displayed on each receipt the user gets, as a result
+    # The background color that will be displayed on each receipt the user gets, as a result
     # of a share with the application.
     #
     # @return [Attribute, nil]

--- a/lib/yoti/data_type/attribute.rb
+++ b/lib/yoti/data_type/attribute.rb
@@ -13,6 +13,10 @@ module Yoti
     POSTAL_ADDRESS = 'postal_address'
     STRUCTURED_POSTAL_ADDRESS = 'structured_postal_address'
     DOCUMENT_IMAGES = 'document_images'
+    APPLICATION_NAME = 'application_name'
+    APPLICATION_LOGO = 'application_logo'
+    APPLICATION_URL = 'application_url'
+    APPLICATION_RECEIPT_BGCOLOR = 'application_receipt_bgcolor'
 
     attr_reader :name, :value, :sources, :verifiers
 

--- a/lib/yoti/data_type/base_profile.rb
+++ b/lib/yoti/data_type/base_profile.rb
@@ -1,0 +1,27 @@
+module Yoti
+  #
+  # Encapsulates Yoti user profile
+  #
+  class BaseProfile
+    #
+    # @param [Object] profile_data
+    #
+    def initialize(profile_data)
+      profile_data = {} unless profile_data.is_a? Object
+      @profile_data = profile_data
+    end
+
+    #
+    # Get attribute value by name.
+    #
+    # @param [String] attr_name
+    #
+    # @return [Attribute, nil]
+    #
+    def get_attribute(attr_name)
+      return nil unless @profile_data.key? attr_name
+
+      @profile_data[attr_name]
+    end
+  end
+end

--- a/lib/yoti/data_type/base_profile.rb
+++ b/lib/yoti/data_type/base_profile.rb
@@ -4,11 +4,17 @@ module Yoti
   #
   class BaseProfile
     #
-    # @param [Object] profile_data
+    # Return all attributes for the profile.
+    #
+    # @return [Hash{String => Yoti::Attribute}]
+    #
+    attr_reader :attributes
+
+    #
+    # @param [Hash{String => Yoti::Attribute}] profile_data
     #
     def initialize(profile_data)
-      profile_data = {} unless profile_data.is_a? Object
-      @profile_data = profile_data
+      @attributes = profile_data.is_a?(Object) ? profile_data : {}
     end
 
     #
@@ -19,9 +25,9 @@ module Yoti
     # @return [Attribute, nil]
     #
     def get_attribute(attr_name)
-      return nil unless @profile_data.key? attr_name
+      return nil unless @attributes.key? attr_name
 
-      @profile_data[attr_name]
+      @attributes[attr_name]
     end
   end
 end

--- a/lib/yoti/data_type/profile.rb
+++ b/lib/yoti/data_type/profile.rb
@@ -2,15 +2,7 @@ module Yoti
   #
   # Encapsulates Yoti user profile
   #
-  class Profile
-    #
-    # @param [Object] profile_data
-    #
-    def initialize(profile_data)
-      profile_data = {} unless profile_data.is_a? Object
-      @profile_data = profile_data
-    end
-
+  class Profile < BaseProfile
     #
     # Selfie is a photograph of the user.
     #
@@ -122,19 +114,6 @@ module Yoti
     #
     def structured_postal_address
       get_attribute(Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS)
-    end
-
-    #
-    # Get attribute value by name.
-    #
-    # @param [String] attr_name
-    #
-    # @return [Attribute, nil]
-    #
-    def get_attribute(attr_name)
-      return nil unless @profile_data.key? attr_name
-
-      @profile_data[attr_name]
     end
 
     protected

--- a/spec/yoti/client_spec.rb
+++ b/spec/yoti/client_spec.rb
@@ -10,6 +10,7 @@ describe 'Yoti::Client' do
     let(:base64_selfie_uri) { activity_details.base64_selfie_uri }
     let(:receipt_id) { activity_details.receipt_id }
     let(:timestamp) { activity_details.timestamp }
+    let(:application_profile) { activity_details.application_profile }
 
     context 'when the encrypted token is nil', type: :api_with_profile do
       it 'raises an ArgumentError' do
@@ -104,6 +105,26 @@ describe 'Yoti::Client' do
       it 'contains the decrypted user ID value' do
         expected_id = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU'
         expect(user_id).to eql(expected_id)
+      end
+    end
+
+    context 'when the application profile has content', type: :api_with_profile do
+      let(:activity_details) { Yoti::Client.get_activity_details(encrypted_connect_token) }
+
+      it 'contains the fetched application profile' do
+        expect(application_profile).not_to be_nil
+      end
+
+      it 'contains the application name' do
+        expect(application_profile.name.value).to eql('Node SDK Test')
+      end
+
+      it 'contains the application url' do
+        expect(application_profile.url.value).to eql('https://example.com')
+      end
+
+      it 'contains the application receipt bg color' do
+        expect(application_profile.receipt_bgcolor.value).to eql('#ffffff')
       end
     end
   end

--- a/spec/yoti/client_spec.rb
+++ b/spec/yoti/client_spec.rb
@@ -119,6 +119,10 @@ describe 'Yoti::Client' do
         expect(application_profile.name.value).to eql('Node SDK Test')
       end
 
+      it 'contains the application logo is nil' do
+        expect(application_profile.logo).to be_nil
+      end
+
       it 'contains the application url' do
         expect(application_profile.url.value).to eql('https://example.com')
       end

--- a/spec/yoti/data_type/application_profile_spec.rb
+++ b/spec/yoti/data_type/application_profile_spec.rb
@@ -1,0 +1,32 @@
+describe 'Yoti::ApplicationProfile' do
+  profile_data = { Yoti::Attribute::APPLICATION_NAME => 'test_name',
+                   Yoti::Attribute::APPLICATION_URL => 'test_url',
+                   Yoti::Attribute::APPLICATION_LOGO => 'test_logo',
+                   Yoti::Attribute::APPLICATION_RECEIPT_BGCOLOR => 'test_receipt_bgcolor' }
+
+  profile = Yoti::ApplicationProfile.new(profile_data)
+
+  describe '.name' do
+    it 'should return test_name' do
+      expect(profile.name).to eql('test_name')
+    end
+  end
+
+  describe '.url' do
+    it 'should return test_url' do
+      expect(profile.url).to eql('test_url')
+    end
+  end
+
+  describe '.logo' do
+    it 'should return test_logo' do
+      expect(profile.logo).to eql('test_logo')
+    end
+  end
+
+  describe '.receipt_bgcolor' do
+    it 'should return test_receipt_bgcolor' do
+      expect(profile.receipt_bgcolor).to eql('test_receipt_bgcolor')
+    end
+  end
+end

--- a/spec/yoti/data_type/application_profile_spec.rb
+++ b/spec/yoti/data_type/application_profile_spec.rb
@@ -1,32 +1,53 @@
 describe 'Yoti::ApplicationProfile' do
-  profile_data = { Yoti::Attribute::APPLICATION_NAME => 'test_name',
-                   Yoti::Attribute::APPLICATION_URL => 'test_url',
-                   Yoti::Attribute::APPLICATION_LOGO => 'test_logo',
-                   Yoti::Attribute::APPLICATION_RECEIPT_BGCOLOR => 'test_receipt_bgcolor' }
+  profile_values = { Yoti::Attribute::APPLICATION_NAME => 'test_name',
+                     Yoti::Attribute::APPLICATION_URL => 'test_url',
+                     Yoti::Attribute::APPLICATION_LOGO => 'test_logo',
+                     Yoti::Attribute::APPLICATION_RECEIPT_BGCOLOR => 'test_receipt_bgcolor' }
+
+  profile_data = profile_values.map do |name, value|
+    [name, Yoti::Attribute.new(name, value, {}, {})]
+  end.to_h
 
   profile = Yoti::ApplicationProfile.new(profile_data)
 
   describe '.name' do
     it 'should return test_name' do
-      expect(profile.name).to eql('test_name')
+      expect(profile.name.value).to eql('test_name')
     end
   end
 
   describe '.url' do
     it 'should return test_url' do
-      expect(profile.url).to eql('test_url')
+      expect(profile.url.value).to eql('test_url')
     end
   end
 
   describe '.logo' do
     it 'should return test_logo' do
-      expect(profile.logo).to eql('test_logo')
+      expect(profile.logo.value).to eql('test_logo')
     end
   end
 
   describe '.receipt_bgcolor' do
     it 'should return test_receipt_bgcolor' do
-      expect(profile.receipt_bgcolor).to eql('test_receipt_bgcolor')
+      expect(profile.receipt_bgcolor.value).to eql('test_receipt_bgcolor')
+    end
+  end
+
+  describe '.get_attribute' do
+    profile_values.each do |key, value|
+      it "'#{key}' should return '#{value}''" do
+        expect(profile.get_attribute(key).value).to eql(value)
+      end
+    end
+  end
+
+  describe '.attributes' do
+    it 'should return all attributes' do
+      expect(profile.attributes.length).to eql(4)
+      profile_values.each do |key, value|
+        expect(profile.attributes[key].value).to eql(value)
+      end
     end
   end
 end

--- a/spec/yoti/data_type/profile_spec.rb
+++ b/spec/yoti/data_type/profile_spec.rb
@@ -1,82 +1,86 @@
 describe 'Yoti::Profile' do
-  profile_data = { Yoti::Attribute::SELFIE => 'test_selfie',
-                   Yoti::Attribute::FAMILY_NAME => 'test_family_name',
-                   Yoti::Attribute::GIVEN_NAMES => 'test_given_names',
-                   Yoti::Attribute::FULL_NAME => 'test_full_name',
-                   Yoti::Attribute::PHONE_NUMBER => 'test_phone_number',
-                   Yoti::Attribute::EMAIL_ADDRESS => 'test_email_address',
-                   Yoti::Attribute::DATE_OF_BIRTH => 'test_date_of_birth',
-                   Yoti::Attribute::GENDER => 'test_gender',
-                   Yoti::Attribute::NATIONALITY => 'test_nationality',
-                   Yoti::Attribute::POSTAL_ADDRESS => 'test_postal_address',
-                   Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS => 'test_structured_address',
-                   Yoti::Attribute::DOCUMENT_IMAGES => 'test_document_images' }
+  profile_values = { Yoti::Attribute::SELFIE => 'test_selfie',
+                     Yoti::Attribute::FAMILY_NAME => 'test_family_name',
+                     Yoti::Attribute::GIVEN_NAMES => 'test_given_names',
+                     Yoti::Attribute::FULL_NAME => 'test_full_name',
+                     Yoti::Attribute::PHONE_NUMBER => 'test_phone_number',
+                     Yoti::Attribute::EMAIL_ADDRESS => 'test_email_address',
+                     Yoti::Attribute::DATE_OF_BIRTH => 'test_date_of_birth',
+                     Yoti::Attribute::GENDER => 'test_gender',
+                     Yoti::Attribute::NATIONALITY => 'test_nationality',
+                     Yoti::Attribute::POSTAL_ADDRESS => 'test_postal_address',
+                     Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS => 'test_structured_address',
+                     Yoti::Attribute::DOCUMENT_IMAGES => 'test_document_images' }
+
+  profile_data = profile_values.map do |name, value|
+    [name, Yoti::Attribute.new(name, value, {}, {})]
+  end.to_h
 
   profile = Yoti::Profile.new(profile_data)
 
   describe '.selfie' do
     it 'should return test_selfie' do
-      expect(profile.selfie).to eql('test_selfie')
+      expect(profile.selfie.value).to eql('test_selfie')
     end
   end
 
   describe '.family_name' do
     it 'should return test_family_name' do
-      expect(profile.family_name).to eql('test_family_name')
+      expect(profile.family_name.value).to eql('test_family_name')
     end
   end
 
   describe '.given_names' do
     it 'should return test_given_names' do
-      expect(profile.given_names).to eql('test_given_names')
+      expect(profile.given_names.value).to eql('test_given_names')
     end
   end
 
   describe '.full_name' do
     it 'should return test_full_name' do
-      expect(profile.full_name).to eql('test_full_name')
+      expect(profile.full_name.value).to eql('test_full_name')
     end
   end
 
   describe '.phone_number' do
     it 'should return test_phone_number' do
-      expect(profile.phone_number).to eql('test_phone_number')
+      expect(profile.phone_number.value).to eql('test_phone_number')
     end
   end
 
   describe '.email_address' do
     it 'should return test_email_address' do
-      expect(profile.email_address).to eql('test_email_address')
+      expect(profile.email_address.value).to eql('test_email_address')
     end
   end
 
   describe '.date_of_birth' do
     it 'should return test_date_of_birth' do
-      expect(profile.date_of_birth).to eql('test_date_of_birth')
+      expect(profile.date_of_birth.value).to eql('test_date_of_birth')
     end
   end
 
   describe '.gender' do
     it 'should return test_gender' do
-      expect(profile.gender).to eql('test_gender')
+      expect(profile.gender.value).to eql('test_gender')
     end
   end
 
   describe '.nationality' do
     it 'should return test_nationality' do
-      expect(profile.nationality).to eql('test_nationality')
+      expect(profile.nationality.value).to eql('test_nationality')
     end
   end
 
   describe '.document_images' do
     it 'should return test_document_images' do
-      expect(profile.document_images).to eql('test_document_images')
+      expect(profile.document_images.value).to eql('test_document_images')
     end
   end
 
   describe '.postal_address' do
     it 'should return test_postal_address' do
-      expect(profile.postal_address).to eql('test_postal_address')
+      expect(profile.postal_address.value).to eql('test_postal_address')
     end
     it 'should return formatted address when postal address not available' do
       structured_address_attribute = Yoti::Attribute.new(
@@ -99,14 +103,23 @@ describe 'Yoti::Profile' do
 
   describe '.structured_postal_address' do
     it 'should return test_structured_address' do
-      expect(profile.structured_postal_address).to eql('test_structured_address')
+      expect(profile.structured_postal_address.value).to eql('test_structured_address')
     end
   end
 
   describe '.get_attribute' do
-    profile_data.each do |key, value|
+    profile_values.each do |key, value|
       it "'#{key}' should return '#{value}''" do
-        expect(profile.get_attribute(key)).to eql(value)
+        expect(profile.get_attribute(key).value).to eql(value)
+      end
+    end
+  end
+
+  describe '.attributes' do
+    it 'should return all attributes' do
+      expect(profile.attributes.length).to eql(12)
+      profile_values.each do |key, value|
+        expect(profile.attributes[key].value).to eql(value)
       end
     end
   end


### PR DESCRIPTION
### Added
- `Yoti::ActivityDetails.application_profile`
- `Yoti::ApplicationProfile`, which extends `Yoti::BaseProfile`

### Changed
- `Yoti::Profile` now extends `Yoti::BaseProfile`

### Deprecated
- `Yoti::ActivityDetails.user_profile`
- `Yoti::ActivityDetails.structured_postal_address`
- `Yoti::Protobuf.current_user`