### PR TITLE
SDK-542: Document Details

### DIFF
--- a/lib/yoti.rb
+++ b/lib/yoti.rb
@@ -21,6 +21,7 @@ require_relative 'yoti/data_type/image'
 require_relative 'yoti/data_type/image_jpeg'
 require_relative 'yoti/data_type/image_png'
 require_relative 'yoti/data_type/multi_value'
+require_relative 'yoti/data_type/document_details'
 
 require_relative 'yoti/util/age_processor'
 require_relative 'yoti/util/anchor_processor'

--- a/lib/yoti/data_type/attribute.rb
+++ b/lib/yoti/data_type/attribute.rb
@@ -21,6 +21,7 @@ module Yoti
     POSTAL_ADDRESS = 'postal_address'
     STRUCTURED_POSTAL_ADDRESS = 'structured_postal_address'
     DOCUMENT_IMAGES = 'document_images'
+    DOCUMENT_DETAILS = 'document_details'
     APPLICATION_NAME = 'application_name'
     APPLICATION_LOGO = 'application_logo'
     APPLICATION_URL = 'application_url'

--- a/lib/yoti/data_type/document_details.rb
+++ b/lib/yoti/data_type/document_details.rb
@@ -76,9 +76,7 @@ module Yoti
       @type = attributes[TYPE_INDEX]
       @issuing_country = attributes[COUNTRY_INDEX]
       @document_number = attributes[NUMBER_INDEX]
-      if attributes.length > 3
-        @expiration_date = parse_date_from_string(attributes[EXPIRATION_INDEX])
-      end
+      @expiration_date = parse_date_from_string(attributes[EXPIRATION_INDEX]) if attributes.length > 3
       @issuing_authority = attributes[AUTHORITY_INDEX] if attributes.length > 4
     end
 

--- a/lib/yoti/data_type/document_details.rb
+++ b/lib/yoti/data_type/document_details.rb
@@ -1,0 +1,96 @@
+module Yoti
+  class DocumentDetails
+    #
+    # The values of the Document Details are in the format and order as defined in this pattern
+    # e.g PASS_CARD GBR 22719564893 - CITIZENCARD, the last two are optionals
+    #
+    VALIDATION_PATTERN = '^([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*$'
+    TYPE_INDEX = 0
+    COUNTRY_INDEX = 1
+    NUMBER_INDEX = 2
+    EXPIRATION_INDEX = 3
+    AUTHORITY_INDEX = 4
+
+    #
+    # Type of the document e.g. PASSPORT | DRIVING_LICENCE | NATIONAL_ID | PASS_CARD
+    #
+    # @return [String]
+    #
+    attr_reader :type
+
+    #
+    # ISO-3166-1 alpha-3 country code, e.g. "GBR"
+    #
+    # @return [String]
+    #
+    attr_reader :issuing_country
+
+    #
+    # Document number (may include letters) from the document.
+    #
+    # @return [String]
+    #
+    attr_reader :document_number
+
+    #
+    # Expiration date of the document in DateTime format. If the document does not expire, this
+    # field will not be present. The time part of this DateTime will default to 00:00:00.
+    #
+    # @return [DateTime]
+    #
+    attr_reader :expiration_date
+
+    #
+    # Can either be a country code (for a state), or the name of the issuing authority.
+    #
+    # @return [String]
+    #
+    attr_reader :issuing_authority
+
+    #
+    # @param [String] value
+    #
+    def initialize(value)
+      validate_value(value)
+      parse_value(value)
+    end
+
+    private
+
+    #
+    # Asserts provided matches VALIDATION_PATTERN
+    #
+    # @param [String] value
+    #
+    def validate_value(value)
+      raise(ArgumentError, "Invalid value for #{self.class.name}") unless /#{VALIDATION_PATTERN}/.match?(value)
+    end
+
+    #
+    # Parses provided value into separate attributes
+    #
+    # @param [String] value
+    #
+    def parse_value(value)
+      attributes = value.split(' ')
+      @type = attributes[TYPE_INDEX]
+      @issuing_country = attributes[COUNTRY_INDEX]
+      @document_number = attributes[NUMBER_INDEX]
+      @expiration_date = parse_date_from_string(attributes[EXPIRATION_INDEX])
+      @issuing_authority = attributes[AUTHORITY_INDEX]
+    end
+
+    #
+    # Converts provided date string into DateTime
+    #
+    # @param [String] date_string
+    #
+    # @return [DateTime]
+    #
+    def parse_date_from_string(date_string)
+      return nil if date_string == '-'
+
+      DateTime.iso8601(date_string)
+    end
+  end
+end

--- a/lib/yoti/data_type/document_details.rb
+++ b/lib/yoti/data_type/document_details.rb
@@ -76,8 +76,10 @@ module Yoti
       @type = attributes[TYPE_INDEX]
       @issuing_country = attributes[COUNTRY_INDEX]
       @document_number = attributes[NUMBER_INDEX]
-      @expiration_date = parse_date_from_string(attributes[EXPIRATION_INDEX])
-      @issuing_authority = attributes[AUTHORITY_INDEX]
+      if attributes.length > 3
+        @expiration_date = parse_date_from_string(attributes[EXPIRATION_INDEX])
+      end
+      @issuing_authority = attributes[AUTHORITY_INDEX] if attributes.length > 4
     end
 
     #

--- a/lib/yoti/data_type/profile.rb
+++ b/lib/yoti/data_type/profile.rb
@@ -116,6 +116,15 @@ module Yoti
       get_attribute(Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS)
     end
 
+    #
+    # Document Details.
+    #
+    # @return [Attribute, nil]
+    #
+    def document_details
+      get_attribute(Yoti::Attribute::DOCUMENT_DETAILS)
+    end
+
     protected
 
     #

--- a/lib/yoti/protobuf/main.rb
+++ b/lib/yoti/protobuf/main.rb
@@ -46,6 +46,8 @@ module Yoti
 
       def value_based_on_attribute_name(value, attr_name)
         case attr_name
+        when Yoti::Attribute::DOCUMENT_DETAILS
+          Yoti::DocumentDetails.new(value)
         when Yoti::Attribute::DOCUMENT_IMAGES
           raise(TypeError, 'Document Images could not be decoded') unless value.is_a?(Yoti::MultiValue)
 

--- a/spec/yoti/data_type/document_details_spec.rb
+++ b/spec/yoti/data_type/document_details_spec.rb
@@ -110,6 +110,11 @@ describe 'Yoti::DocumentDetails' do
         expect(document_details.expiration_date).to be_nil
       end
     end
+    describe '.issuing_authority' do
+      it 'should return issuing authority' do
+        expect(document_details.issuing_authority).to eql('CITIZENCARD')
+      end
+    end
   end
 
   context 'when the expiration date is invalid' do

--- a/spec/yoti/data_type/document_details_spec.rb
+++ b/spec/yoti/data_type/document_details_spec.rb
@@ -50,7 +50,7 @@ describe 'Yoti::DocumentDetails' do
         expect(document_details.expiration_date).to be_nil
       end
     end
-  end  
+  end
 
   context 'when there are two optional attributes' do
     document_details = Yoti::DocumentDetails.new('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA')

--- a/spec/yoti/data_type/document_details_spec.rb
+++ b/spec/yoti/data_type/document_details_spec.rb
@@ -26,6 +26,32 @@ describe 'Yoti::DocumentDetails' do
     end
   end
 
+  context 'when there are no optional attributes' do
+    let :document_details do
+      Yoti::DocumentDetails.new('DRIVING_LICENCE GBR 1234abc')
+    end
+    describe '.type' do
+      it 'should return DRIVING_LICENCE' do
+        expect(document_details.type).to eql 'DRIVING_LICENCE'
+      end
+    end
+    describe '.issuing_country' do
+      it 'should return GBR' do
+        expect(document_details.issuing_country).to eql 'GBR'
+      end
+    end
+    describe '.document_number' do
+      it 'should return 1234abc' do
+        expect(document_details.document_number).to eql('1234abc')
+      end
+    end
+    describe '.expiration_date' do
+      it 'should return nil' do
+        expect(document_details.expiration_date).to be_nil
+      end
+    end
+  end  
+
   context 'when there are two optional attributes' do
     document_details = Yoti::DocumentDetails.new('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA')
     describe '.type' do

--- a/spec/yoti/data_type/document_details_spec.rb
+++ b/spec/yoti/data_type/document_details_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe 'Yoti::DocumentDetails' do
+  context 'when there is one optional attribute' do
+    document_details = Yoti::DocumentDetails.new('PASSPORT GBR 01234567 2020-01-01')
+    describe '.type' do
+      it 'should return PASSPORT' do
+        expect(document_details.type).to eql('PASSPORT')
+      end
+    end
+    describe '.issuing_country' do
+      it 'should return GBR' do
+        expect(document_details.issuing_country).to eql('GBR')
+      end
+    end
+    describe '.document_number' do
+      it 'should return 01234567' do
+        expect(document_details.document_number).to eql('01234567')
+      end
+    end
+    describe '.expiration_date' do
+      it 'should return 2020-01-01' do
+        expect(document_details.expiration_date).to be_a_kind_of(DateTime)
+        expect(document_details.expiration_date.to_s).to eql('2020-01-01T00:00:00+00:00')
+      end
+    end
+  end
+
+  context 'when there are two optional attributes' do
+    document_details = Yoti::DocumentDetails.new('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA')
+    describe '.type' do
+      it 'should return DRIVING_LICENCE' do
+        expect(document_details.type).to eql('DRIVING_LICENCE')
+      end
+    end
+    describe '.issuing_country' do
+      it 'should return GBR' do
+        expect(document_details.issuing_country).to eql('GBR')
+      end
+    end
+    describe '.document_number' do
+      it 'should return 1234abc' do
+        expect(document_details.document_number).to eql('1234abc')
+      end
+    end
+    describe '.expiration_date' do
+      it 'should return 2016-05-01' do
+        expect(document_details.expiration_date).to be_a_kind_of(DateTime)
+        expect(document_details.expiration_date.to_s).to eql('2016-05-01T00:00:00+00:00')
+      end
+    end
+    describe '.issuing_authority' do
+      it 'should return DVLA' do
+        expect(document_details.issuing_authority).to eql('DVLA')
+      end
+    end
+  end
+
+  context 'when value is empty' do
+    it 'should raise ArgumentError' do
+      expect { Yoti::DocumentDetails.new('') }
+        .to raise_error(ArgumentError, 'Invalid value for Yoti::DocumentDetails')
+    end
+  end
+
+  context 'when the country is invalid' do
+    it 'should raise ArgumentError' do
+      expect { Yoti::DocumentDetails.new('PASSPORT 13 1234abc 2016-05-01') }
+        .to raise_error(ArgumentError, 'Invalid value for Yoti::DocumentDetails')
+    end
+  end
+
+  context 'when the document number is invalid' do
+    it 'should raise ArgumentError' do
+      expect { Yoti::DocumentDetails.new('PASSPORT GBR $%^$%^£ 2016-05-01') }
+        .to raise_error(ArgumentError, 'Invalid value for Yoti::DocumentDetails')
+    end
+  end
+
+  context 'when the expiration date is missing' do
+    document_details = Yoti::DocumentDetails.new('PASS_CARD GBR 22719564893 - CITIZENCARD')
+    describe '.expiration_date' do
+      it 'should return null' do
+        expect(document_details.expiration_date).to be_nil
+      end
+    end
+  end
+
+  context 'when the expiration date is invalid' do
+    it 'should raise ArgumentError' do
+      expect { Yoti::DocumentDetails.new('PASSPORT GBR 1234abc X016-05-01') }
+        .to raise_error(ArgumentError, 'invalid date')
+    end
+  end
+
+  context 'when the value is less than three words' do
+    it 'should raise ArgumentError' do
+      expect { Yoti::DocumentDetails.new('PASS_CARD GBR') }
+        .to raise_error(ArgumentError, 'Invalid value for Yoti::DocumentDetails')
+    end
+  end
+
+  context 'when the value has six attributes' do
+    it 'should ignore the sixth attribute' do
+      document_details = Yoti::DocumentDetails.new('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA someThirdAttribute')
+      expect(document_details.type).to eql('DRIVING_LICENCE')
+      expect(document_details.issuing_country).to eql('GBR')
+      expect(document_details.document_number).to eql('1234abc')
+      expect(document_details.expiration_date.to_s).to eql('2016-05-01T00:00:00+00:00')
+    end
+  end
+end

--- a/spec/yoti/data_type/profile_spec.rb
+++ b/spec/yoti/data_type/profile_spec.rb
@@ -10,7 +10,8 @@ describe 'Yoti::Profile' do
                      Yoti::Attribute::NATIONALITY => 'test_nationality',
                      Yoti::Attribute::POSTAL_ADDRESS => 'test_postal_address',
                      Yoti::Attribute::STRUCTURED_POSTAL_ADDRESS => 'test_structured_address',
-                     Yoti::Attribute::DOCUMENT_IMAGES => 'test_document_images' }
+                     Yoti::Attribute::DOCUMENT_IMAGES => 'test_document_images',
+                     Yoti::Attribute::DOCUMENT_DETAILS => 'test_document_details' }
 
   profile_data = profile_values.map do |name, value|
     [name, Yoti::Attribute.new(name, value, {}, {})]
@@ -107,6 +108,12 @@ describe 'Yoti::Profile' do
     end
   end
 
+  describe '.document_details' do
+    it 'should return test_document_details' do
+      expect(profile.document_details.value).to eql('test_document_details')
+    end
+  end
+
   describe '.get_attribute' do
     profile_values.each do |key, value|
       it "'#{key}' should return '#{value}''" do
@@ -117,7 +124,7 @@ describe 'Yoti::Profile' do
 
   describe '.attributes' do
     it 'should return all attributes' do
-      expect(profile.attributes.length).to eql(12)
+      expect(profile.attributes.length).to eql(13)
       profile_values.each do |key, value|
         expect(profile.attributes[key].value).to eql(value)
       end

--- a/spec/yoti/protobuf/protobuf_spec.rb
+++ b/spec/yoti/protobuf/protobuf_spec.rb
@@ -208,6 +208,21 @@ describe 'Yoti::Protobuf' do
       end
     end
 
+    context 'when the name is document_details' do
+      let(:value) { 'PASSPORT GBR 01234567 2016-05-01 DVLA' }
+      let(:attr_name) { Yoti::Attribute::DOCUMENT_DETAILS }
+
+      it 'returns document details object' do
+        expect(subject).to be_a_kind_of(Yoti::DocumentDetails)
+        expect(subject.type).to eql('PASSPORT')
+        expect(subject.issuing_country).to eql('GBR')
+        expect(subject.document_number).to eql('01234567')
+        expect(subject.issuing_authority).to eql('DVLA')
+        expect(subject.expiration_date).to be_a_kind_of(DateTime)
+        expect(subject.expiration_date.to_s).to eql('2016-05-01T00:00:00+00:00')
+      end
+    end
+
     context 'when the name is document_images and the value is not a multi value' do
       let(:value) { 'a string' }
       let(:attr_name) { Yoti::Attribute::DOCUMENT_IMAGES }


### PR DESCRIPTION
### Added
- `Yoti::DocumentDetails`
- `Yoti::Profile#document_details`

> Note: We can't add document details to the example projects until support for dynamic scenarios has been added