### PR TITLE
SDK-1177 sandbox requirements

### DIFF
--- a/lib/yoti/data_type/profile.rb
+++ b/lib/yoti/data_type/profile.rb
@@ -1,3 +1,5 @@
+require_relative 'base_profile'
+
 module Yoti
   #
   # Encapsulates Yoti user profile

--- a/lib/yoti/ssl.rb
+++ b/lib/yoti/ssl.rb
@@ -60,9 +60,10 @@ module Yoti
       end
 
       # Reset and reload the Private Key used for SSL functions
-      def reload
+      def reload!
         @private_key = nil
         @pem = nil
+        nil
       end
 
       private

--- a/lib/yoti/ssl.rb
+++ b/lib/yoti/ssl.rb
@@ -59,6 +59,12 @@ module Yoti
         ssl_decipher.update(text) + ssl_decipher.final
       end
 
+      # Reset and reload the Private Key used for SSL functions
+      def reload
+        @private_key = nil
+        @pem = nil
+      end
+
       private
 
       def private_key


### PR DESCRIPTION
### TODO
 * [x] Merge SDK-542

### Additions
 * Yoti::SSL.reload! forces the SDK to discard and reload the private key from file after the configuration is changed after creating a sandbox.