### PR TITLE
SDK-1177: Change Puma IP Binding in Sinatra demo project

### DIFF
--- a/examples/sinatra/Procfile
+++ b/examples/sinatra/Procfile
@@ -1,1 +1,1 @@
-web: puma -b 'ssl://localhost:4567?cert=keys/server.crt&key=keys/server.key'
+web: puma -b 'ssl://0.0.0.0:4567?cert=keys/server.crt&key=keys/server.key'


### PR DESCRIPTION
Change the binding of puma to 0.0.0.0 so the example project is
accessible inside a docker container