### PR TITLE
SDK-1209: Do not set X-Yoti-Auth-Key by default, only on requests that

### DIFF
--- a/lib/yoti/http/profile_request.rb
+++ b/lib/yoti/http/profile_request.rb
@@ -18,6 +18,7 @@ module Yoti
       yoti_request.encrypted_connect_token = @encrypted_connect_token
       yoti_request.http_method = 'GET'
       yoti_request.endpoint = 'profile'
+      yoti_request.set_auth_key = true
       yoti_request
     end
   end

--- a/lib/yoti/http/request.rb
+++ b/lib/yoti/http/request.rb
@@ -14,6 +14,9 @@ module Yoti
     # @return [Hash] the body sent with the request
     attr_accessor :payload
 
+    # @return [Boolean] Whether the X-Auth-Key header should be set to the client's key
+    attr_accessor :set_auth_key
+
     # Makes a HTTP request after signing the headers
     # @return [Hash] the body from the HTTP request
     def body
@@ -21,7 +24,7 @@ module Yoti
       raise RequestError, 'The payload needs to be a hash.' unless @payload.to_s.empty? || @payload.is_a?(Hash)
 
       res = Net::HTTP.start(uri.hostname, Yoti.configuration.api_port, use_ssl: https_uri?) do |http|
-        signed_request = SignedRequest.new(unsigned_request, path, @payload).sign
+        signed_request = SignedRequest.new(unsigned_request, path, @payload).sign(with_auth_key: @set_auth_key)
         http.request(signed_request)
       end
 

--- a/lib/yoti/http/signed_request.rb
+++ b/lib/yoti/http/signed_request.rb
@@ -10,13 +10,11 @@ module Yoti
       @auth_key = Yoti::SSL.auth_key_from_pem
     end
 
-    def sign
-      @http_req['X-Yoti-Auth-Key'] = @auth_key
+    def sign(with_auth_key: false)
+      @http_req['X-Yoti-Auth-Key'] = @auth_key if with_auth_key
       @http_req['X-Yoti-Auth-Digest'] = message_signature
       @http_req['X-Yoti-SDK'] = Yoti.configuration.sdk_identifier
       @http_req['X-Yoti-SDK-Version'] = "#{Yoti.configuration.sdk_identifier}-#{Yoti::VERSION}"
-      @http_req['Content-Type'] = 'application/json'
-      @http_req['Accept'] = 'application/json'
       @http_req
     end
 

--- a/spec/yoti/http/signed_request_spec.rb
+++ b/spec/yoti/http/signed_request_spec.rb
@@ -16,7 +16,7 @@ describe 'Yoti::SignedRequest' do
   end
 
   describe '#sign' do
-    let(:signed) { signed_request.send(:sign) }
+    let(:signed) { signed_request.sign(with_auth_key: true) }
     it 'return a signed request' do
       expect(signed).to be_a(Net::HTTP::Get)
       expect(signed['X-Yoti-Auth-Key']).to eql('MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs9zAY5K9O92zfmRhxBO0NX8Dg7UyyIaLE5GdbCMimlccew2p8LN6P8EDUoU7hiCbW1EQ/cp4iZVIp7UPA3AO/ecuejs2DjkFQOeMGnSlwD0pk74ZI3ammQtYm2ml47IWGrciMh4dPIPh0SOF+tVD0kHhAB9cMaj96Ij2De60Y7SeqvIXUHCtnoHId7Zk5I71mtewAnb9Gpx+wPnr2gpX/uUqkh+3ZHsF2eNCpw/ICvKj4UkNXopUyBemDp3n/s7u8TFyewp7ipPbFxDmxZKJT9SjZNFFe/jc2V/R2uC9qSFRKpTsxqmXggjiBlH46cpyg2SeYFj1p5bkpKZ10b3iOwIDAQAB')
@@ -24,8 +24,6 @@ describe 'Yoti::SignedRequest' do
       expect(signed['X-Yoti-SDK']).to eql('Ruby')
       expect(signed['X-Yoti-SDK-Version']).to eql("Ruby-#{Yoti::VERSION}")
       expect(signed['X-Yoti-SDK-Version']).to match(/Ruby-\d+\.\d+\.\d+/)
-      expect(signed['Content-Type']).to eql('application/json')
-      expect(signed['Accept']).to eql('application/json')
     end
   end
 


### PR DESCRIPTION
require it

### Changed
 * Content-Type and Accept headers no longer set as they are not required
 * `sign` takes an optional named boolean which sets whether the X-Yoti-Auth-Key should be written.
 * Profile request sets the X-Yoti-Auth-Key