### PR TITLE
SDK-1577: Fix Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ jobs:
   include:
     - &test
       stage: Test
-      rvm: 2.6
+      rvm: 2.7
       before_install:
         - gem install bundler
       install:
         - bundle install
       script:
         - bundle exec rake
+    - <<: *test
+      rvm: 2.6
     - <<: *test
       rvm: 2.5
     - <<: *test
@@ -28,7 +30,7 @@ jobs:
     - &coverage
       stage: coverage
       name: Coveralls
-      rvm: 2.4
+      rvm: 2.7
       before_install:
         - gem install bundler
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - &test
       stage: Test
-      rvm: 2.4
+      rvm: 2.6
       before_install:
         - gem install bundler
       install:
@@ -17,7 +17,14 @@ jobs:
     - <<: *test
       rvm: 2.5
     - <<: *test
-      rvm: 2.6
+      rvm: 2.4
+      install:
+        # Install google-protobuf version compatible with Ruby 2.4
+        - bundle add google-protobuf -v '~> 3.11.4'
+        - bundle install
+      script:
+        # Run tests only as `bundle add` causes RuboCop offences
+        - bundle exec rake spec
     - &coverage
       stage: coverage
       name: Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ jobs:
     - <<: *test
       rvm: 2.4
       install:
-        # Install google-protobuf version compatible with Ruby 2.4
-        - bundle add google-protobuf -v '~> 3.11.4'
+        # Install dependencies compatible with Ruby 2.4
+        - bundle add google-protobuf -v '~> 3.11.4' --skip-install
         - bundle install
       script:
         # Run tests only as `bundle add` causes RuboCop offences

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,7 @@ jobs:
     - <<: *test
       rvm: 2.4
       install:
-        # Install dependencies compatible with Ruby 2.4
-        - bundle add google-protobuf -v '~> 3.11.4' --skip-install
-        - bundle install
-      script:
-        # Run tests only as `bundle add` causes RuboCop offences
-        - bundle exec rake spec
+        - BUNDLE_FORCE_RUBY_PLATFORM=1 bundle install
     - &coverage
       stage: coverage
       name: Coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,35 +16,6 @@ bundle exec guard
 
 Although this gem supports Ruby 2.0.0, in order to use the latest development dependencies you have to use at least Ruby 2.2.2.
 
-If you wish to compile `.proto` definitions to Ruby, you will need to install [Google's Protocol Buffers](http://code.google.com/p/protobuf).
-
-### OSX
-
-```shell
-brew install protobuf
-```
-
-### Ubuntu
-
-```shell
-sudo apt-get install -y protobuf
-```
-
-This gem relies heavily on the [Ruby Protobuf][] gem. For more information on how Google Protobuf works, please see the [Wiki pages][].
-
-Compiling the common and attribute `.proto` definitions can be done with the following commands:
-
-```shell
-cd lib/yoti/protobuf/v1
-protoc -I definitions/attribute-public-api/attrpubapi_v1 --ruby_out ./attribute_public_api definitions/attribute-public-api/attrpubapi_v1/*.proto
-protoc -I definitions/common-public-api/compubapi_v1/ --ruby_out ./common_public_api definitions/common-public-api/compubapi_v1/*.proto
-```
-
-These commands will overwrite the current protobuf Ruby modules, which have been modified. If the protobuf files have to be updated, a good idea would be to change them manually, or generate the files in a new location, and compare the content.
-
-[Ruby Protobuf]: https://github.com/ruby-protobuf/protobuf/
-[Wiki Pages]:    https://github.com/ruby-protobuf/protobuf/wiki
-
 ## Requirements
 
 ### Code coverage

--- a/lib/yoti/dynamic_share_service/policy/dynamic_policy.rb
+++ b/lib/yoti/dynamic_share_service/policy/dynamic_policy.rb
@@ -105,19 +105,19 @@ module Yoti
       end
 
       def with_family_name(options = {})
-        with_wanted_attribute_by_name Attribute::FAMILY_NAME, options
+        with_wanted_attribute_by_name Attribute::FAMILY_NAME, **options
       end
 
       def with_given_names(options = {})
-        with_wanted_attribute_by_name Attribute::GIVEN_NAMES, options
+        with_wanted_attribute_by_name Attribute::GIVEN_NAMES, **options
       end
 
       def with_full_name(options = {})
-        with_wanted_attribute_by_name Attribute::FULL_NAME, options
+        with_wanted_attribute_by_name Attribute::FULL_NAME, **options
       end
 
       def with_date_of_birth(options = {})
-        with_wanted_attribute_by_name Attribute::DATE_OF_BIRTH, options
+        with_wanted_attribute_by_name Attribute::DATE_OF_BIRTH, **options
       end
 
       #
@@ -138,42 +138,42 @@ module Yoti
       # @param [Integer] derivation
       #
       def with_age_over(age, options = {})
-        with_age_derived_attribute(Attribute::AGE_OVER + age.to_s, options)
+        with_age_derived_attribute(Attribute::AGE_OVER + age.to_s, **options)
       end
 
       #
       # @param [Integer] derivation
       #
       def with_age_under(age, options = {})
-        with_age_derived_attribute(Attribute::AGE_UNDER + age.to_s, options)
+        with_age_derived_attribute(Attribute::AGE_UNDER + age.to_s, **options)
       end
 
       def with_gender(options = {})
-        with_wanted_attribute_by_name Attribute::GENDER, options
+        with_wanted_attribute_by_name Attribute::GENDER, **options
       end
 
       def with_postal_address(options = {})
-        with_wanted_attribute_by_name(Attribute::POSTAL_ADDRESS, options)
+        with_wanted_attribute_by_name(Attribute::POSTAL_ADDRESS, **options)
       end
 
       def with_structured_postal_address(options = {})
-        with_wanted_attribute_by_name(Attribute::STRUCTURED_POSTAL_ADDRESS, options)
+        with_wanted_attribute_by_name(Attribute::STRUCTURED_POSTAL_ADDRESS, **options)
       end
 
       def with_nationality(options = {})
-        with_wanted_attribute_by_name(Attribute::NATIONALITY, options)
+        with_wanted_attribute_by_name(Attribute::NATIONALITY, **options)
       end
 
       def with_phone_number(options = {})
-        with_wanted_attribute_by_name(Attribute::PHONE_NUMBER, options)
+        with_wanted_attribute_by_name(Attribute::PHONE_NUMBER, **options)
       end
 
       def with_selfie(options = {})
-        with_wanted_attribute_by_name(Attribute::SELFIE, options)
+        with_wanted_attribute_by_name(Attribute::SELFIE, **options)
       end
 
       def with_email(options = {})
-        with_wanted_attribute_by_name(Attribute::EMAIL_ADDRESS, options)
+        with_wanted_attribute_by_name(Attribute::EMAIL_ADDRESS, **options)
       end
 
       def with_document_details

--- a/yoti.gemspec
+++ b/yoti.gemspec
@@ -23,9 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency 'activesupport', '~> 5.0' # Pin activesupport library to 5.x for Ruby 2.4 support
-  spec.add_dependency 'google-protobuf', '~> 3.7', '>= 3.7.0'
-  spec.add_dependency 'protobuf', '~> 3.6'
+  spec.add_dependency 'google-protobuf', '~> 3.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls', '~> 0.8'


### PR DESCRIPTION
### Fixed
- Install `google-protobuf` `3.11` for Ruby `2.4` tests
  _Support removed in https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0_
- Ruby `2.7` deprecation warnings

### Removed
- Removed `protobuf` dependency and instructions to compile from proto files
- Removed `activesupport ` dependency - this was a runtime dependency of `protobuf`

### Added
- Test compatibility with Ruby `2.7`

> Note: Ruby `2.4` users will need to specify a compatible version of `google-protobuf` e.g.
> ```
> gem 'google-protobuf', '~>3.11.4'
> ```