### PR TITLE
SDK-1079: Add RequestBuilder

### DIFF
--- a/lib/yoti.rb
+++ b/lib/yoti.rb
@@ -26,7 +26,8 @@ require_relative 'yoti/data_type/document_details'
 
 require_relative 'yoti/util/age_processor'
 require_relative 'yoti/util/anchor_processor'
-require_relative 'yoti/util/log.rb'
+require_relative 'yoti/util/log'
+require_relative 'yoti/util/validation'
 
 require_relative 'yoti/activity_details'
 require_relative 'yoti/client'

--- a/lib/yoti/client.rb
+++ b/lib/yoti/client.rb
@@ -7,9 +7,11 @@ module Yoti
     #
     # Performs all the steps required to get the decrypted profile from an API request
     #
-    # @param encrypted_connect_token [String] token provided as a base 64 string
+    # @param [String] encrypted_connect_token
+    #   Token provided as a base 64 string
     #
-    # @return [Object] an ActivityDetails instance encapsulating the user profile
+    # @return [ActivityDetails]
+    #   An ActivityDetails instance encapsulating the user profile
     #
     def self.get_activity_details(encrypted_connect_token)
       receipt = Yoti::ProfileRequest.new(encrypted_connect_token).receipt
@@ -22,6 +24,13 @@ module Yoti
       ActivityDetails.new(receipt, user_profile, application_profile, extra_data)
     end
 
+    #
+    # Perform AML check
+    #
+    # @param [AmlProfile] aml_profile
+    #
+    # @return [<Hash>]
+    #
     def self.aml_check(aml_profile)
       Yoti::AmlCheckRequest.new(aml_profile).response
     end

--- a/lib/yoti/data_type/age_verification.rb
+++ b/lib/yoti/data_type/age_verification.rb
@@ -37,7 +37,7 @@ module Yoti
     attr_reader :age
 
     #
-    # @param [Yoti::Attribute]
+    # @param [Yoti::Attribute] attribute
     #
     def initialize(attribute)
       raise(ArgumentError, "'#{attribute.name}' is not a valid age verification") unless /^[^:]+:(?!.*:)[0-9]+$/.match?(attribute.name)

--- a/lib/yoti/data_type/base_profile.rb
+++ b/lib/yoti/data_type/base_profile.rb
@@ -37,7 +37,7 @@ module Yoti
     #
     # @param [String] name
     #
-    # @returns [Array]
+    # @return [Array]
     #
     def find_attributes_starting_with(name)
       @attributes.select { |key| key.to_s.start_with?(name) }

--- a/lib/yoti/dynamic_share_service/extension/thirdparty_attribute_extension.rb
+++ b/lib/yoti/dynamic_share_service/extension/thirdparty_attribute_extension.rb
@@ -38,7 +38,7 @@ module Yoti
       end
 
       #
-      # @param [String] *names
+      # @param [String] names
       #
       # @return [self]
       #

--- a/lib/yoti/dynamic_share_service/policy/dynamic_policy.rb
+++ b/lib/yoti/dynamic_share_service/policy/dynamic_policy.rb
@@ -16,8 +16,8 @@ module Yoti
         false
       end
 
-      def to_json(*args)
-        as_json.to_json(*args)
+      def to_json(*_args)
+        as_json.to_json
       end
 
       def as_json(*_args)
@@ -135,14 +135,14 @@ module Yoti
       end
 
       #
-      # @param [Integer] derivation
+      # @param [Integer] age
       #
       def with_age_over(age, options = {})
         with_age_derived_attribute(Attribute::AGE_OVER + age.to_s, **options)
       end
 
       #
-      # @param [Integer] derivation
+      # @param [Integer] age
       #
       def with_age_under(age, options = {})
         with_age_derived_attribute(Attribute::AGE_UNDER + age.to_s, **options)

--- a/lib/yoti/errors.rb
+++ b/lib/yoti/errors.rb
@@ -3,7 +3,22 @@ module Yoti
   class ProtobufError < StandardError; end
 
   # Raises exceptions related to API requests
-  class RequestError < StandardError; end
+  class RequestError < StandardError
+    attr_reader :response
+
+    def initialize(message, response = nil)
+      super(append_response_message(message, response))
+      @response = response
+    end
+
+    private
+
+    def append_response_message(message, response)
+      return message if response.nil? || response.body.empty?
+
+      "#{message}: #{response.body}"
+    end
+  end
 
   # Raises exceptions related to OpenSSL actions
   class SslError < StandardError; end

--- a/lib/yoti/http/aml_check_request.rb
+++ b/lib/yoti/http/aml_check_request.rb
@@ -1,13 +1,16 @@
 module Yoti
   # Manage the API's AML check requests
   class AmlCheckRequest
+    #
+    # @param [AmlProfile] aml_profile
+    #
     def initialize(aml_profile)
       @aml_profile = aml_profile
       @payload = aml_profile.payload
       @request = request
     end
 
-    # @return [String] a JSON representation of the AML check response
+    # @return [Hash] a JSON representation of the AML check response
     def response
       JSON.parse(@request.body)
     end
@@ -15,11 +18,14 @@ module Yoti
     private
 
     def request
-      yoti_request = Yoti::Request.new
-      yoti_request.http_method = 'POST'
-      yoti_request.endpoint = 'aml-check'
-      yoti_request.payload = @payload
-      yoti_request
+      Yoti::Request
+        .builder
+        .with_http_method('POST')
+        .with_base_url(Yoti.configuration.api_endpoint)
+        .with_endpoint('aml-check')
+        .with_query_param('appId', Yoti.configuration.client_sdk_id)
+        .with_payload(@payload)
+        .build
     end
   end
 end

--- a/lib/yoti/http/payloads/aml_address.rb
+++ b/lib/yoti/http/payloads/aml_address.rb
@@ -7,6 +7,10 @@ module Yoti
     # @return [String] the postcode required for USA, optional otherwise
     attr_accessor :post_code
 
+    #
+    # @param [String] country
+    # @param [String] post_code
+    #
     def initialize(country, post_code = nil)
       raise AmlError, 'AmlAddress requires a country.' if country.to_s.empty?
 

--- a/lib/yoti/http/payloads/aml_profile.rb
+++ b/lib/yoti/http/payloads/aml_profile.rb
@@ -1,6 +1,12 @@
 module Yoti
   # Manages the AML check Profile object
   class AmlProfile
+    #
+    # @param [String] given_names
+    # @param [String] family_name
+    # @param [AmlAddress] aml_address
+    # @param [String] ssn
+    #
     def initialize(given_names, family_name, aml_address, ssn = nil)
       @given_names = given_names
       @family_name = family_name
@@ -11,7 +17,7 @@ module Yoti
       raise AmlError, 'Request for USA require a valid SSN and postcode.' if usa_invalid
     end
 
-    # @return [Object] the AML check request body
+    # @return [Hash] the AML check request body
     def payload
       {
         given_names: @given_names,

--- a/lib/yoti/http/profile_request.rb
+++ b/lib/yoti/http/profile_request.rb
@@ -1,6 +1,9 @@
 module Yoti
   # Manage the API's profile requests
   class ProfileRequest
+    #
+    # @param [String] encrypted_connect_token
+    #
     def initialize(encrypted_connect_token)
       @encrypted_connect_token = encrypted_connect_token
       @request = request
@@ -14,12 +17,14 @@ module Yoti
     private
 
     def request
-      yoti_request = Yoti::Request.new
-      yoti_request.add_header('X-Yoti-Auth-Key', Yoti::SSL.auth_key_from_pem)
-      yoti_request.encrypted_connect_token = @encrypted_connect_token
-      yoti_request.http_method = 'GET'
-      yoti_request.endpoint = 'profile'
-      yoti_request
+      Yoti::Request
+        .builder
+        .with_http_method('GET')
+        .with_base_url(Yoti.configuration.api_endpoint)
+        .with_endpoint("profile/#{Yoti::SSL.decrypt_token(@encrypted_connect_token)}")
+        .with_query_param('appId', Yoti.configuration.client_sdk_id)
+        .with_header('X-Yoti-Auth-Key', Yoti::SSL.auth_key_from_pem)
+        .build
     end
   end
 end

--- a/lib/yoti/http/request.rb
+++ b/lib/yoti/http/request.rb
@@ -3,8 +3,15 @@ require 'securerandom'
 module Yoti
   # Manage the API's HTTPS requests
   class Request
+    # @deprecated will be removed in 2.0.0 - token is now provided with the endpoint
     # @return [String] the URL token received from Yoti Connect
     attr_accessor :encrypted_connect_token
+
+    # @return [String] the base URL
+    attr_writer :base_url
+
+    # @return [Hash] query params to add to the request
+    attr_accessor :query_params
 
     # @return [String] the HTTP method used for the request
     # The allowed methods are: GET, DELETE, POST, PUT, PATCH
@@ -13,36 +20,93 @@ module Yoti
     # @return [String] the API endpoint for the request
     attr_accessor :endpoint
 
-    # @return [Hash] the body sent with the request
+    # @return [#to_json,String] the body sent with the request
     attr_accessor :payload
 
     def initialize
       @headers = {}
     end
 
+    #
+    # @return [RequestBuilder]
+    #
+    def self.builder
+      RequestBuilder.new
+    end
+
+    #
     # Adds a HTTP header to the request
+    #
+    # @param [String] header
+    # @param [String] value
+    #
     def add_header(header, value)
       @headers[header] = value
     end
 
+    #
     # Makes a HTTP request after signing the headers
-    # @return [Hash] the body from the HTTP request
-    def body
+    #
+    # @return [HTTPResponse]
+    #
+    def execute
       raise RequestError, 'The request requires a HTTP method.' unless @http_method
-      raise RequestError, 'The payload needs to be a hash.' unless @payload.to_s.empty? || @payload.is_a?(Hash)
 
-      res = Net::HTTP.start(uri.hostname, Yoti.configuration.api_port, use_ssl: https_uri?) do |http|
+      http_res = Net::HTTP.start(uri.hostname, Yoti.configuration.api_port, use_ssl: https_uri?) do |http|
         signed_request = SignedRequest.new(unsigned_request, path, @payload).sign
         http.request(signed_request)
       end
 
-      raise RequestError, "Unsuccessful Yoti API call: #{res.message}" unless res.code == '200'
+      raise RequestError.new("Unsuccessful Yoti API call: #{http_res.message}", http_res) unless response_is_success(http_res)
 
-      res.body
+      http_res
+    end
+
+    #
+    # Makes a HTTP request and returns the body after signing the headers
+    #
+    # @return [String]
+    #
+    def body
+      execute.body
+    end
+
+    #
+    # @return [String] the base URL
+    #
+    def base_url
+      @base_url ||= Yoti.configuration.api_endpoint
     end
 
     private
 
+    #
+    # @param [Net::HTTPResponse] http_res
+    #
+    # @return [Boolean]
+    #
+    def response_is_success(http_res)
+      http_res.code.to_i >= 200 && http_res.code.to_i < 300
+    end
+
+    #
+    # Adds payload to provided HTTP request
+    #
+    # @param [Net::HTTPRequest] http_req
+    #
+    def add_payload(http_req)
+      return if @payload.to_s.empty?
+
+      if @payload.is_a?(String)
+        http_req.body = @payload
+      elsif @payload.respond_to?(:to_json)
+        http_req.body = @payload.to_json
+      end
+    end
+
+    #
+    # @return [Net::HTTPRequest] the unsigned HTTP request
+    #
     def unsigned_request
       case @http_method
       when 'GET'
@@ -51,13 +115,13 @@ module Yoti
         http_req = Net::HTTP::Delete.new(uri)
       when 'POST'
         http_req = Net::HTTP::Post.new(uri)
-        http_req.body = @payload.to_json unless @payload.to_s.empty?
+        add_payload(http_req)
       when 'PUT'
         http_req = Net::HTTP::Put.new(uri)
-        http_req.body = @payload.to_json unless @payload.to_s.empty?
+        add_payload(http_req)
       when 'PATCH'
         http_req = Net::HTTP::Patch.new(uri)
-        http_req.body = @payload.to_json unless @payload.to_s.empty?
+        add_payload(http_req)
       else
         raise RequestError, "Request method not allowed: #{@http_method}"
       end
@@ -69,22 +133,27 @@ module Yoti
       http_req
     end
 
+    #
+    # @return [URI] the full request URI
+    #
     def uri
-      @uri ||= URI(Yoti.configuration.api_endpoint + path)
+      @uri ||= URI(base_url + path)
     end
 
+    #
+    # @return [String] the path with query string
+    #
     def path
       @path ||= begin
-        nonce = SecureRandom.uuid
-        timestamp = Time.now.to_i
-
-        "/#{@endpoint}/#{token}"\
-        "?nonce=#{nonce}"\
-        "&timestamp=#{timestamp}"\
-        "&appId=#{Yoti.configuration.client_sdk_id}"
+        "/#{@endpoint}/#{token}".chomp('/') + "?#{query_string}"
       end
     end
 
+    #
+    # @deprecated will be removed in 2.0.0 - token is now provided with the endpoint
+    #
+    # @return [String] the decrypted connect token
+    #
     def token
       return '' unless @encrypted_connect_token
 
@@ -93,6 +162,137 @@ module Yoti
 
     def https_uri?
       uri.scheme == 'https'
+    end
+
+    #
+    # Builds query string including nonce and timestamp
+    #
+    # @return [String]
+    #
+    def query_string
+      params = {
+        nonce: SecureRandom.uuid,
+        timestamp: Time.now.to_i
+      }
+
+      if @query_params.nil?
+        # @deprecated this default will be removed in 2.0.0
+        # Append appId when no custom query params are provided.
+        params.merge!(appId: Yoti.configuration.client_sdk_id)
+      else
+        Validation.assert_is_a(Hash, @query_params, 'query_params')
+        params.merge!(@query_params)
+      end
+
+      params.map do |k, v|
+        CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s)
+      end.join('&')
+    end
+  end
+
+  #
+  # Builder for {Request}
+  #
+  class RequestBuilder
+    def initialize
+      @headers = {}
+      @query_params = {}
+    end
+
+    #
+    # Sets the base URL
+    #
+    # @param [String] base_url
+    #
+    # @return [self]
+    #
+    def with_base_url(base_url)
+      Validation.assert_is_a(String, base_url, 'base_url')
+      @base_url = base_url
+      self
+    end
+
+    #
+    # Adds a HTTP header to the request
+    #
+    # @param [String] header
+    # @param [String] value
+    #
+    # @return [self]
+    #
+    def with_header(header, value)
+      Validation.assert_is_a(String, header, 'header')
+      Validation.assert_is_a(String, value, 'value')
+      @headers[header] = value
+      self
+    end
+
+    #
+    # Adds a query parameter to the request
+    #
+    # @param [String] key
+    # @param [String] value
+    #
+    # @return [self]
+    #
+    def with_query_param(key, value)
+      Validation.assert_is_a(String, key, 'key')
+      Validation.assert_is_a(String, value, 'value')
+      @query_params[key] = value
+      self
+    end
+
+    #
+    # Sets the HTTP method
+    #
+    # @param [String] http_method
+    #
+    # @return [self]
+    #
+    def with_http_method(http_method)
+      Validation.assert_is_a(String, http_method, 'http_method')
+      @http_method = http_method
+      self
+    end
+
+    #
+    # Sets the API endpoint for the request
+    #
+    # @param [String] endpoint
+    #
+    # @return [self]
+    #
+    def with_endpoint(endpoint)
+      Validation.assert_is_a(String, endpoint, 'endpoint')
+      @endpoint = endpoint
+      self
+    end
+
+    #
+    # Sets the body sent with the request
+    #
+    # @param [#to_json,String] payload
+    #
+    # @return [self]
+    #
+    def with_payload(payload)
+      Validation.assert_respond_to(:to_json, payload, 'payload') unless payload.is_a?(String)
+      @payload = payload
+      self
+    end
+
+    #
+    # @return [Request]
+    #
+    def build
+      request = Request.new
+      request.base_url = @base_url
+      request.endpoint = @endpoint
+      request.query_params = @query_params
+      request.http_method = @http_method
+      request.payload = @payload
+      @headers.map { |k, v| request.add_header(k, v) }
+      request
     end
   end
 end

--- a/lib/yoti/http/signed_request.rb
+++ b/lib/yoti/http/signed_request.rb
@@ -3,6 +3,11 @@ require 'base64'
 module Yoti
   # Converts a basic Net::HTTP request into a Yoti Signed Request
   class SignedRequest
+    #
+    # @param [Net::HTTPRequest] unsigned_request
+    # @param [String] path
+    # @param [#to_json,String] payload
+    #
     def initialize(unsigned_request, path, payload = {})
       @http_req = unsigned_request
       @path = path
@@ -10,6 +15,9 @@ module Yoti
       @auth_key = Yoti::SSL.auth_key_from_pem
     end
 
+    #
+    # @return [Net::HTTPRequest]
+    #
     def sign
       @http_req['X-Yoti-Auth-Digest'] = message_signature
       @http_req['X-Yoti-SDK'] = Yoti.configuration.sdk_identifier
@@ -20,18 +28,19 @@ module Yoti
     private
 
     def message_signature
-      @message_signature ||= Yoti::SSL.get_secure_signature("#{http_method}&#{@path}#{payload_string}")
+      @message_signature ||= Yoti::SSL.get_secure_signature("#{http_method}&#{@path}#{base64_payload}")
     end
 
     def http_method
       @http_req.method
     end
 
-    # Create the base64 encoded request body
-    def payload_string
+    def base64_payload
       return '' unless @payload
 
-      '&' + Base64.strict_encode64(@payload.to_json)
+      payload_string = @payload.is_a?(String) ? @payload : @payload.to_json
+
+      '&' + Base64.strict_encode64(payload_string)
     end
   end
 end

--- a/lib/yoti/ssl.rb
+++ b/lib/yoti/ssl.rb
@@ -48,7 +48,7 @@ module Yoti
 
       # Uses the decrypted receipt key and the current user's iv to decode the text
       # @param key [String] base 64 decoded key
-      # @param iv [String] base 64 decoded iv
+      # @param user_iv [String] base 64 decoded iv
       # @param text [String] base 64 decoded cyphered text
       # @return [String] base 64 decoded deciphered text
       def decipher(key, user_iv, text)

--- a/lib/yoti/util/anchor_processor.rb
+++ b/lib/yoti/util/anchor_processor.rb
@@ -7,7 +7,7 @@ module Yoti
   #
   class AnchorProcessor
     #
-    # @param [Array<Yoti::Protobuf::Attrpubapi::Anchor>]
+    # @param [Array<Yoti::Protobuf::Attrpubapi::Anchor>] anchors_list
     #
     def initialize(anchors_list)
       @anchors_list = anchors_list

--- a/lib/yoti/util/validation.rb
+++ b/lib/yoti/util/validation.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Yoti
+  class Validation
+    #
+    # @param value
+    # @param [String] name
+    #
+    def self.assert_not_nil(value, name)
+      return unless value.nil?
+
+      raise(ArgumentError, "#{name} must not be nil")
+    end
+
+    #
+    # @param [Class] type
+    # @param value
+    # @param [String] name
+    # @param [Boolean] nilable
+    #
+    def self.assert_is_a(type, value, name, nilable = false)
+      return if nilable && value.nil?
+      return if value.is_a?(type)
+
+      raise(ArgumentError, "#{name} must be a #{type.name}")
+    end
+
+    #
+    # @param [Symbol] method
+    # @param value
+    # @param [String] name
+    #
+    def self.assert_respond_to(method, value, name)
+      assert_not_nil(value, name)
+
+      return if value.respond_to?(method)
+
+      raise(ArgumentError, "#{name} must respond to #{method}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,14 +8,15 @@ require 'webmock/rspec'
 
 require 'yoti'
 
-def stub_api_requests_v1(method = :get, response = 'profile', endpoint = '[a-zA-Z]*', status = [200])
-  stub_response = File.read("spec/sample-data/responses/#{response}.json")
-  stub_request(method, %r{https:\/\/api.yoti.com\/api\/v1\/#{endpoint}\/(.)*})
-    .to_return(
-      status: status,
-      body: stub_response,
-      headers: { 'Content-Type' => 'application/json' }
-    )
+def stub_api_requests_v1(method = :get, response = 'profile', endpoint = '[a-zA-Z]*', status = [200], request_body = nil)
+  response_body = File.read("spec/sample-data/responses/#{response}.json")
+  stub = stub_request(method, %r{https:\/\/api.yoti.com\/api\/v1\/#{endpoint}(.)*})
+  stub.with(body: request_body) unless request_body.nil?
+  stub.to_return(
+    status: status,
+    body: response_body,
+    headers: { 'Content-Type' => 'application/json' }
+  )
 end
 
 RSpec.configure do |config|

--- a/spec/yoti/dynamic_share_service/share_url_spec.rb
+++ b/spec/yoti/dynamic_share_service/share_url_spec.rb
@@ -65,4 +65,16 @@ describe 'Yoti::DynamicSharingService::create_share_url' do
         )
     end
   end
+
+  context '.create_share_url_query' do
+    it 'returns query string with nonce and timestamp' do
+      expect(Yoti::DynamicSharingService.create_share_url_query).to match(/^\?nonce=.*&timestamp=.*/)
+    end
+  end
+
+  context '.create_share_url_endpoint' do
+    it 'returns path with SDK ID' do
+      expect(Yoti::DynamicSharingService.create_share_url_endpoint).to eql("/qrcodes/apps/#{Yoti.configuration.client_sdk_id}")
+    end
+  end
 end

--- a/spec/yoti/http/profile_request_spec.rb
+++ b/spec/yoti/http/profile_request_spec.rb
@@ -18,9 +18,8 @@ describe 'Yoti::ProfileRequest' do
     it 'sets the instance variable @request' do
       expect(yoti_request).to be_a(Yoti::Request)
 
-      expect(yoti_request.encrypted_connect_token).to eql(encrypted_connect_token)
       expect(yoti_request.http_method).to eql('GET')
-      expect(yoti_request.endpoint).to eql('profile')
+      expect(yoti_request.endpoint).to eql("profile/#{Yoti::SSL.decrypt_token(encrypted_connect_token)}")
     end
   end
 

--- a/spec/yoti/http/request_spec.rb
+++ b/spec/yoti/http/request_spec.rb
@@ -32,6 +32,16 @@ describe 'Yoti::Request' do
           )
         )
       end
+
+      it 'raises Yoti::RequestError with response object' do
+        request.http_method = 'GET'
+
+        begin
+          raise 'Request did not throw' if request.body
+        rescue Yoti::RequestError => e
+          expect(e.response.body).to eql(response_body)
+        end
+      end
     end
 
     context 'with a HTTP method', type: :api_empty do

--- a/spec/yoti/http/signed_request_spec.rb
+++ b/spec/yoti/http/signed_request_spec.rb
@@ -26,20 +26,20 @@ describe 'Yoti::SignedRequest' do
     end
   end
 
-  describe '#payload_string' do
-    let(:payload_string) { signed_request.send(:payload_string) }
+  describe '#base64_payload' do
+    let(:base64_payload) { signed_request.send(:base64_payload) }
 
     context 'without a payload' do
       it 'returns an empty string' do
         signed_request.instance_variable_set(:@payload, nil)
-        expect(payload_string).to be_empty
+        expect(base64_payload).to be_empty
       end
     end
 
-    context 'witha payload' do
+    context 'with a payload' do
       it 'returns a base64 encoded string' do
         signed_request.instance_variable_set(:@payload, payload_aml)
-        expect(payload_string).to eql('&eyJnaXZlbl9uYW1lcyI6IiIsImZhbWlseV9uYW1lIjoiIiwic3NuIjoiIiwiYWRkcmVzcyI6eyJwb3N0X2NvZGUiOiIiLCJjb3VudHJ5IjoiIn19')
+        expect(base64_payload).to eql('&eyJnaXZlbl9uYW1lcyI6IiIsImZhbWlseV9uYW1lIjoiIiwic3NuIjoiIiwiYWRkcmVzcyI6eyJwb3N0X2NvZGUiOiIiLCJjb3VudHJ5IjoiIn19')
       end
     end
   end

--- a/spec/yoti/util/validation_spec.rb
+++ b/spec/yoti/util/validation_spec.rb
@@ -1,0 +1,56 @@
+describe 'Yoti::Validation' do
+  let(:some_string) { 'some_string' }
+  let(:some_name) { 'some_name' }
+
+  describe '.assert_is_a' do
+    context 'when value is valid' do
+      it 'should not raise error' do
+        [
+          [some_string, String],
+          [123, Integer],
+          [{}, Hash],
+          [[], Array]
+        ].each do |value, type|
+          expect { Yoti::Validation.assert_is_a(type, value, some_name) }
+            .not_to raise_error
+        end
+      end
+    end
+    context 'when value is invalid' do
+      it 'should raise error' do
+        expect { Yoti::Validation.assert_is_a(Integer, some_string, some_name) }
+          .to raise_error(ArgumentError, "#{some_name} must be a Integer")
+      end
+    end
+  end
+
+  describe '.assert_not_nil' do
+    context 'when value not nil' do
+      it 'should not raise error' do
+        expect { Yoti::Validation.assert_not_nil(some_string, some_name) }
+          .not_to raise_error
+      end
+    end
+    context 'when value is nil' do
+      it 'should raise error' do
+        expect { Yoti::Validation.assert_not_nil(nil, some_name) }
+          .to raise_error(ArgumentError, "#{some_name} must not be nil")
+      end
+    end
+  end
+
+  describe '.assert_respond_to' do
+    context 'when value does respond to method' do
+      it 'should not raise error' do
+        expect { Yoti::Validation.assert_respond_to(:to_s, some_string, some_name) }
+          .not_to raise_error
+      end
+    end
+    context 'when value does not respond to method' do
+      it 'should raise error' do
+        expect { Yoti::Validation.assert_respond_to(:unknown_method, some_string, some_name) }
+          .to raise_error(ArgumentError, "#{some_name} must respond to unknown_method")
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Preparation for #97 

### Added
- `Yoti::RequestBuilder` - builder for `Yoti::Request`

### Deprecated
- `Yoti::Request#encrypted_connect_token` token is now provided with the endpoint
- `appId` query param is now only added by `Yoti::Request` when `query_params` are `nil`
- `Yoti::DynamicSharingService::Share.create_share_url_query` no longer in use
- `Yoti::DynamicSharingService::Share.create_share_url_endpoint` no longer in use