### PR TITLE
SDK-1393: Sonar Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       install:
         - bundle install
       script:
-        - bundle exec rake
+        - bundle exec rake test
     - <<: *test
       rvm: 2.6
     - <<: *test
@@ -31,5 +31,5 @@ jobs:
           organization: "getyoti"
       if: type == pull_request OR branch = master
       script:
-        - bundle exec rake
+        - bundle exec rake spec
         - sonar-scanner

--- a/Rakefile
+++ b/Rakefile
@@ -6,13 +6,15 @@ require 'yaml'
 # Tests                        #
 ################################
 
-RSpec::Core::RakeTask.new(:spec) do |t|
+RSpec::Core::RakeTask.new(:test_yoti) do |t|
   t.pattern = ['spec/yoti']
 end
 
 RSpec::Core::RakeTask.new(:test_generators) do |t|
   t.pattern = ['spec/generators']
 end
+
+RSpec::Core::RakeTask.new(:spec)
 
 ################################
 # Rubocop                      #
@@ -43,4 +45,5 @@ end
 # Defaults                     #
 ################################
 
-task default: %i[spec test_generators rubocop]
+task default: %i[spec rubocop]
+task test: %i[test_yoti test_generators rubocop]

--- a/spec/generators/yoti/install/install_generator_spec.rb
+++ b/spec/generators/yoti/install/install_generator_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'generator_spec'
 require 'generators/yoti/install/install_generator.rb'
 


### PR DESCRIPTION
> Fix for #103 

### Fixed
-  Include all tests for coverage reports

> Note: the following test coverage exclusions have been added to sonarcloud.io
> - `version.rb` is required by the gemspec before coverage is recorded
> - `lib/generators/yoti/install/templates/yoti.rb` is a template file, so not included in coverage report