### PR TITLE
SDK-1625: Doc Scan error message

### DIFF
--- a/lib/yoti.rb
+++ b/lib/yoti.rb
@@ -51,6 +51,7 @@ require_relative 'yoti/share/attribute_issuance_details'
 
 require_relative 'yoti/doc_scan/client'
 require_relative 'yoti/doc_scan/constants'
+require_relative 'yoti/doc_scan/errors'
 
 require_relative 'yoti/doc_scan/session/create/create_session_result'
 require_relative 'yoti/doc_scan/session/create/requested_check'

--- a/lib/yoti/doc_scan/client.rb
+++ b/lib/yoti/doc_scan/client.rb
@@ -18,15 +18,18 @@ module Yoti
             'session_specification'
           )
 
-          response = create_request
-                     .with_http_method('POST')
-                     .with_endpoint('sessions')
-                     .with_payload(session_specification)
-                     .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-                     .build
-                     .execute
+          request = create_request
+                    .with_http_method('POST')
+                    .with_endpoint('sessions')
+                    .with_payload(session_specification)
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .build
 
-          Yoti::DocScan::Session::Create::CreateSessionResult.new(JSON.parse(response.body))
+          begin
+            Yoti::DocScan::Session::Create::CreateSessionResult.new(JSON.parse(request.execute.body))
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         #
@@ -39,14 +42,17 @@ module Yoti
         def get_session(session_id)
           Validation.assert_is_a(String, session_id, 'session_id')
 
-          response = create_request
-                     .with_http_method('GET')
-                     .with_endpoint(session_path(session_id))
-                     .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-                     .build
-                     .execute
+          request = create_request
+                    .with_http_method('GET')
+                    .with_endpoint(session_path(session_id))
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .build
 
-          Yoti::DocScan::Session::Retrieve::GetSessionResult.new(JSON.parse(response.body))
+          begin
+            Yoti::DocScan::Session::Retrieve::GetSessionResult.new(JSON.parse(request.execute.body))
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         #
@@ -58,12 +64,17 @@ module Yoti
         def delete_session(session_id)
           Validation.assert_is_a(String, session_id, 'session_id')
 
-          create_request
-            .with_http_method('DELETE')
-            .with_endpoint(session_path(session_id))
-            .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-            .build
-            .execute
+          request = create_request
+                    .with_http_method('DELETE')
+                    .with_endpoint(session_path(session_id))
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .build
+
+          begin
+            request.execute
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         #
@@ -79,17 +90,22 @@ module Yoti
           Validation.assert_is_a(String, session_id, 'session_id')
           Validation.assert_is_a(String, media_id, 'media_id')
 
-          response = create_request
-                     .with_http_method('GET')
-                     .with_endpoint(media_path(session_id, media_id))
-                     .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-                     .build
-                     .execute
+          request = create_request
+                    .with_http_method('GET')
+                    .with_endpoint(media_path(session_id, media_id))
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .build
 
-          Yoti::Media.new(
-            response.body,
-            response.get_fields('content-type')[0]
-          )
+          begin
+            response = request.execute
+
+            Yoti::Media.new(
+              response.body,
+              response.get_fields('content-type')[0]
+            )
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         #
@@ -103,12 +119,17 @@ module Yoti
           Validation.assert_is_a(String, session_id, 'session_id')
           Validation.assert_is_a(String, media_id, 'media_id')
 
-          create_request
-            .with_http_method('DELETE')
-            .with_endpoint(media_path(session_id, media_id))
-            .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-            .build
-            .execute
+          request = create_request
+                    .with_http_method('DELETE')
+                    .with_endpoint(media_path(session_id, media_id))
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .build
+
+          begin
+            request.execute
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         #
@@ -117,13 +138,16 @@ module Yoti
         # @return [Yoti::DocScan::Support::SupportedDocumentsResponse]
         #
         def supported_documents
-          response = create_request
-                     .with_http_method('GET')
-                     .with_endpoint('supported-documents')
-                     .build
-                     .execute
+          request = create_request
+                    .with_http_method('GET')
+                    .with_endpoint('supported-documents')
+                    .build
 
-          Yoti::DocScan::Support::SupportedDocumentsResponse.new(JSON.parse(response.body))
+          begin
+            Yoti::DocScan::Support::SupportedDocumentsResponse.new(JSON.parse(request.execute.body))
+          rescue Yoti::RequestError => e
+            raise Yoti::DocScan::Error.wrap(e)
+          end
         end
 
         private

--- a/lib/yoti/doc_scan/errors.rb
+++ b/lib/yoti/doc_scan/errors.rb
@@ -1,0 +1,81 @@
+require 'json'
+
+module Yoti
+  module DocScan
+    #
+    # Raises exceptions related to Doc Scan API requests
+    #
+    class Error < RequestError
+      def initialize(msg = nil, response = nil)
+        super(msg, response)
+
+        @default_message = msg
+      end
+
+      def message
+        @message ||= format_message
+      end
+
+      #
+      # Wraps an existing error
+      #
+      # @param [Error] error
+      #
+      # @return [self]
+      #
+      def self.wrap(error)
+        new(error.message, error.response)
+      end
+
+      private
+
+      #
+      # Formats error message from response.
+      #
+      # @return [String]
+      #
+      def format_message
+        return @default_message if @response.nil? || @response['Content-Type'] != 'application/json'
+
+        json = JSON.parse(@response.body)
+        format_response(json) || @default_message
+      end
+
+      #
+      # Format JSON error response.
+      #
+      # @param [Hash] json
+      #
+      # @return [String, nil]
+      #
+      def format_response(json)
+        return nil if json['code'].nil? || json['message'].nil?
+
+        code_message = "#{json['code']} - #{json['message']}"
+
+        unless json['errors'].nil?
+          property_errors = format_property_errors(json['errors'])
+
+          return "#{code_message}: #{property_errors.compact.join(', ')}" if property_errors.count.positive?
+        end
+
+        code_message
+      end
+
+      #
+      # Format property errors.
+      #
+      # @param [Array<Hash>] errors
+      #
+      # @return [Array<String>]
+      #
+      def format_property_errors(errors)
+        errors
+          .map do |e|
+            "#{e['property']} \"#{e['message']}\"" if e['property'] && e['message']
+          end
+          .compact
+      end
+    end
+  end
+end

--- a/lib/yoti/errors.rb
+++ b/lib/yoti/errors.rb
@@ -7,16 +7,14 @@ module Yoti
     attr_reader :response
 
     def initialize(message, response = nil)
-      super(append_response_message(message, response))
+      super(message)
       @response = response
     end
 
-    private
+    def message
+      return super if @response.nil? || @response.body.empty?
 
-    def append_response_message(message, response)
-      return message if response.nil? || response.body.empty?
-
-      "#{message}: #{response.body}"
+      "#{super}: #{@response.body}"
     end
   end
 

--- a/spec/yoti/doc_scan/client_spec.rb
+++ b/spec/yoti/doc_scan/client_spec.rb
@@ -21,12 +21,8 @@ def stub_doc_scan_api_request(
 end
 
 describe 'Yoti::DocScan::Client' do
-  context '.create_session' do
-    before(:context) do
-      stub_doc_scan_api_request(method: :post, endpoint: 'sessions')
-    end
-
-    it 'creates a create session result' do
+  describe '.create_session' do
+    let(:spec) do
       some_sdk_config = Yoti::DocScan::Session::Create::SdkConfig
                         .builder
                         .with_allows_camera
@@ -42,116 +38,220 @@ describe 'Yoti::DocScan::Client' do
                                 .builder
                                 .build
 
-      spec = Yoti::DocScan::Session::Create::SessionSpecification
-             .builder
-             .with_client_session_token_ttl(400)
-             .with_resources_ttl(86840)
-             .with_user_tracking_id('some-tracking-id')
-             .with_sdk_config(some_sdk_config)
-             .with_requested_check(some_authenticity_check)
-             .with_notifications(some_notification_config)
-             .build
+      Yoti::DocScan::Session::Create::SessionSpecification
+        .builder
+        .with_client_session_token_ttl(400)
+        .with_resources_ttl(86840)
+        .with_user_tracking_id('some-tracking-id')
+        .with_sdk_config(some_sdk_config)
+        .with_requested_check(some_authenticity_check)
+        .with_notifications(some_notification_config)
+        .build
+    end
 
-      result = Yoti::DocScan::Client.create_session(spec)
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(method: :post, endpoint: 'sessions')
+      end
 
-      expect(result).to be_a(Yoti::DocScan::Session::Create::CreateSessionResult)
+      it 'creates a create session result' do
+        result = Yoti::DocScan::Client.create_session(spec)
+
+        expect(result).to be_a(Yoti::DocScan::Session::Create::CreateSessionResult)
+      end
+    end
+
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(method: :post, endpoint: 'sessions', status: 400)
+      end
+
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.create_session(spec) }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 
-  context '.get_session' do
-    before(:context) do
-      stub_doc_scan_api_request(
-        method: :get,
-        endpoint: 'sessions/some-id\?nonce=.*&sdkId=.*&timestamp=.*',
-        query: hash_including(
-          sdkId: Yoti.configuration.client_sdk_id,
-          nonce: /.*/,
-          timestamp: /.*/
+  describe '.get_session' do
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'sessions/some-id\?nonce=.*&sdkId=.*&timestamp=.*',
+          query: hash_including(
+            sdkId: Yoti.configuration.client_sdk_id,
+            nonce: /.*/,
+            timestamp: /.*/
+          )
         )
-      )
+      end
+
+      it 'gets a session result' do
+        result = Yoti::DocScan::Client.get_session('some-id')
+
+        expect(result).to be_a(Yoti::DocScan::Session::Retrieve::GetSessionResult)
+      end
     end
 
-    it 'gets a session result' do
-      result = Yoti::DocScan::Client.get_session('some-id')
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'sessions/some-id',
+          status: 400
+        )
+      end
 
-      expect(result).to be_a(Yoti::DocScan::Session::Retrieve::GetSessionResult)
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.get_session('some-id') }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 
-  context '.delete_session' do
-    before(:context) do
-      stub_doc_scan_api_request(
-        method: :delete,
-        endpoint: 'sessions/some-id',
-        query: hash_including(
-          sdkId: Yoti.configuration.client_sdk_id,
-          nonce: /.*/,
-          timestamp: /.*/
+  describe '.delete_session' do
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :delete,
+          endpoint: 'sessions/some-id',
+          query: hash_including(
+            sdkId: Yoti.configuration.client_sdk_id,
+            nonce: /.*/,
+            timestamp: /.*/
+          )
         )
-      )
+      end
+
+      it 'deletes a session' do
+        expect { Yoti::DocScan::Client.delete_session('some-id') }.not_to raise_error
+      end
     end
 
-    it 'deletes a session' do
-      expect { Yoti::DocScan::Client.delete_session('some-id') }.not_to raise_error
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :delete,
+          endpoint: 'sessions/some-id',
+          status: 400
+        )
+      end
+
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.delete_session('some-id') }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 
-  context '.get_media_content' do
-    before(:context) do
-      stub_doc_scan_api_request(
-        method: :get,
-        endpoint: 'sessions/some-id/media/some-media-id/content',
-        query: hash_including(
-          sdkId: Yoti.configuration.client_sdk_id,
-          nonce: /.*/,
-          timestamp: /.*/
+  describe '.get_media_content' do
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'sessions/some-id/media/some-media-id/content',
+          query: hash_including(
+            sdkId: Yoti.configuration.client_sdk_id,
+            nonce: /.*/,
+            timestamp: /.*/
+          )
         )
-      )
+      end
+
+      it 'gets media content' do
+        media = Yoti::DocScan::Client.get_media_content('some-id', 'some-media-id')
+
+        expect(media).to be_a(Yoti::Media)
+        expect(media.content).to be('{}')
+        expect(media.mime_type).to be('application/json')
+      end
     end
 
-    it 'gets media content' do
-      media = Yoti::DocScan::Client.get_media_content('some-id', 'some-media-id')
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'sessions/some-id/media/some-media-id/content',
+          status: 400
+        )
+      end
 
-      expect(media).to be_a(Yoti::Media)
-      expect(media.content).to be('{}')
-      expect(media.mime_type).to be('application/json')
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.get_media_content('some-id', 'some-media-id') }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 
-  context '.delete_media_content' do
-    before(:context) do
-      stub_doc_scan_api_request(
-        method: :delete,
-        endpoint: 'sessions/some-id/media/some-media-id/content',
-        query: hash_including(
-          sdkId: Yoti.configuration.client_sdk_id,
-          nonce: /.*/,
-          timestamp: /.*/
+  describe '.delete_media_content' do
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :delete,
+          endpoint: 'sessions/some-id/media/some-media-id/content',
+          query: hash_including(
+            sdkId: Yoti.configuration.client_sdk_id,
+            nonce: /.*/,
+            timestamp: /.*/
+          )
         )
-      )
+      end
+
+      it 'deletes media content' do
+        expect { Yoti::DocScan::Client.delete_media_content('some-id', 'some-media-id') }.not_to raise_error
+      end
     end
 
-    it 'deletes media content' do
-      expect { Yoti::DocScan::Client.delete_media_content('some-id', 'some-media-id') }.not_to raise_error
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :delete,
+          endpoint: 'sessions/some-id/media/some-media-id/content',
+          status: 400
+        )
+      end
+
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.delete_media_content('some-id', 'some-media-id') }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 
-  context '.supported_documents' do
-    before(:context) do
-      stub_doc_scan_api_request(
-        method: :get,
-        endpoint: 'supported-documents',
-        query: hash_including(
-          nonce: /.*/,
-          timestamp: /.*/
+  describe '.supported_documents' do
+    context 'when response is success' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'supported-documents',
+          query: hash_including(
+            nonce: /.*/,
+            timestamp: /.*/
+          )
         )
-      )
+      end
+
+      it 'gets supported documents' do
+        documents = Yoti::DocScan::Client.supported_documents
+
+        expect(documents).to be_a(Yoti::DocScan::Support::SupportedDocumentsResponse)
+      end
     end
 
-    it 'gets supported documents' do
-      documents = Yoti::DocScan::Client.supported_documents
+    context 'when response is failure' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          endpoint: 'supported-documents',
+          status: 400
+        )
+      end
 
-      expect(documents).to be_a(Yoti::DocScan::Support::SupportedDocumentsResponse)
+      it 'raises Yoti::DocScan::Error' do
+        expect { Yoti::DocScan::Client.supported_documents }
+          .to raise_error(Yoti::DocScan::Error)
+      end
     end
   end
 end

--- a/spec/yoti/doc_scan/errors_spec.rb
+++ b/spec/yoti/doc_scan/errors_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Yoti::DocScan::Error' do
+  let(:some_error_message) { 'SOME_ERROR_MESSAGE' }
+  let(:some_code) { 'SOME_CODE' }
+  let(:some_message) { 'SOME_MESSAGE' }
+  let(:some_property) { 'SOME_PROPERTY' }
+  let(:some_property_message) { 'SOME_PROPERTY_MESSAGE' }
+  let(:some_other_property) { 'SOME_OTHER_PROPERTY' }
+  let(:some_other_property_message) { 'SOME_OTHER_PROPERTY_MESSAGE' }
+  let(:some_response) { instance_double(Net::HTTPResponse, body: response_body, :[] => 'application/json') }
+  let(:some_request_error) do
+    Yoti::RequestError.new(some_error_message, some_response)
+  end
+
+  context 'when created with message' do
+    let(:error) do
+      Yoti::DocScan::Error.new(some_error_message)
+    end
+
+    it 'uses provided error message' do
+      expect(error.message).to eql(some_error_message)
+    end
+
+    it 'is a Yoti::RequestError' do
+      expect(error).to be_a(Yoti::RequestError)
+    end
+  end
+
+  context 'when created with message and response' do
+    let(:error) do
+      Yoti::DocScan::Error.new(some_error_message, some_response)
+    end
+    let(:response_body) { { code: some_code, message: some_message }.to_json }
+
+    it 'uses formatted response' do
+      expect(error.message).to eql("#{some_code} - #{some_message}")
+    end
+  end
+
+  context 'when wrapped error response has code and message' do
+    let(:error) do
+      Yoti::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) { { code: some_code, message: some_message }.to_json }
+
+    it 'includes code and message in error message' do
+      expect(error.message).to eql("#{some_code} - #{some_message}")
+    end
+  end
+
+  context 'when wrapped error response has code, message and errors' do
+    let(:error) do
+      Yoti::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) do
+      {
+        code: some_code,
+        message: some_message,
+        errors: [
+          {
+            property: some_property,
+            message: some_property_message
+          },
+          {
+            property: some_other_property,
+            message: some_other_property_message
+          }
+        ]
+      }.to_json
+    end
+
+    it 'includes code, message and errors in error message' do
+      error.message
+      error.message
+      expect(error.message)
+        .to eql("#{some_code} - #{some_message}: #{some_property} \"#{some_property_message}\", #{some_other_property} \"#{some_other_property_message}\"")
+    end
+  end
+
+  context 'when wrapped error response has no code or message' do
+    let(:error) do
+      Yoti::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) { { some: 'json' }.to_json }
+
+    it 'uses wrapped error message with response' do
+      expect(error.message).to eql("#{some_error_message}: #{response_body}")
+    end
+  end
+
+  context 'when wrapped error response is not available' do
+    let(:error) do
+      Yoti::DocScan::Error.wrap(some_request_error)
+    end
+    let(:some_response) { nil }
+
+    it 'uses wrapped error message' do
+      expect(error.message).to eql(some_error_message)
+    end
+  end
+end


### PR DESCRIPTION
### Changed
- `Yoti::DocScan::Client` calls now raises `Yoti::DocScan::Error < RequestError` with formatted error response (was `RequestError` with JSON response)
  > Note: `rescue Yoti::RequestError` will continue to work as before

#### Message format
```
{CODE} - {MESSAGE}
```
```
{CODE} - {MESSAGE}: {PROPERTY} "{PROPERTY_MESSAGE}", {OTHER_PROPERTY} "{OTHER_PROPERTY_MESSAGE}"
```

#### Example
```
PAYLOAD_VALIDATION - There were errors validating the payload: sdk_config.allowed_capture_methods "Value is not valid", sdk_config.font_colour "provided colour must be a valid Hex Code", sdk_config.locale "must not be blank"
```