### PR TITLE
SDK-1413: Max Retries

### DIFF
--- a/lib/yoti/http/profile_request.rb
+++ b/lib/yoti/http/profile_request.rb
@@ -24,6 +24,7 @@ module Yoti
         .with_endpoint("profile/#{Yoti::SSL.decrypt_token(@encrypted_connect_token)}")
         .with_query_param('appId', Yoti.configuration.client_sdk_id)
         .with_header('X-Yoti-Auth-Key', Yoti::SSL.auth_key_from_pem)
+        .with_max_retries(0)
         .build
     end
   end

--- a/spec/yoti/http/profile_request_spec.rb
+++ b/spec/yoti/http/profile_request_spec.rb
@@ -21,6 +21,10 @@ describe 'Yoti::ProfileRequest' do
       expect(yoti_request.http_method).to eql('GET')
       expect(yoti_request.endpoint).to eql("profile/#{Yoti::SSL.decrypt_token(encrypted_connect_token)}")
     end
+
+    it 'sets max retries to 0' do
+      expect(yoti_request.max_retries).to eql(0)
+    end
   end
 
   describe '#receipt', type: :api_with_profile do


### PR DESCRIPTION
### Fixed
- Prevent retries when fetching profile

> Note: `Net::HTTP#max_retries=` isn't available in Ruby 2.4, so we have a check to prevent it being used with `!http.respond_to?(:max_retries)`