### PR TITLE
SDK-1666: Base64 URL encode issuance tokens

### DIFF
--- a/lib/yoti/share/attribute_issuance_details.rb
+++ b/lib/yoti/share/attribute_issuance_details.rb
@@ -28,7 +28,7 @@ module Yoti
       # @param [Yoti::Protobuf::Sharepubapi::ThirdPartyAttribute] data_entry
       #
       def initialize(data_entry)
-        @token = Base64.strict_encode64(data_entry.issuance_token)
+        @token = Base64.urlsafe_encode64(data_entry.issuance_token, padding: false)
         begin
           @expiry_date = DateTime.parse(data_entry.issuing_attributes.expiry_date)
         rescue ArgumentError

--- a/lib/yoti/version.rb
+++ b/lib/yoti/version.rb
@@ -1,4 +1,4 @@
 module Yoti
   # @return [String] the gem's current version
-  VERSION = '1.8.0'.freeze
+  VERSION = '1.8.1'.freeze
 end

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization = getyoti
 
 sonar.projectKey = getyoti:ruby
 sonar.projectName = Ruby SDK
-sonar.projectVersion = 1.8.0
+sonar.projectVersion = 1.8.1
 
 sonar.language = ruby
 sonar.exclusions = **/protobuf/**.rb, coverage/**, spec/sample-data/**

--- a/spec/yoti/share/attribute_issuance_details_spec.rb
+++ b/spec/yoti/share/attribute_issuance_details_spec.rb
@@ -29,7 +29,7 @@ describe 'Yoti::Share::AttributeIssuanceDetails' do
       'tokenValue'
     end
     let :b64token do
-      Base64.strict_encode64 token
+      Base64.urlsafe_encode64(token, padding: false)
     end
     let :now do
       DateTime.now
@@ -52,6 +52,7 @@ describe 'Yoti::Share::AttributeIssuanceDetails' do
     end
     it 'sets the token value' do
       expect(attribute_issuance_details.token).to eql b64token
+      expect(Base64.urlsafe_decode64(attribute_issuance_details.token)).to eql token
     end
     it 'sets the expiry date' do
       expect(attribute_issuance_details.expiry_date).to eql now

--- a/spec/yoti/share/extra_data_spec.rb
+++ b/spec/yoti/share/extra_data_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 require 'yoti'
+require 'base64'
 
 def create_extra_data_proto(*rows)
   extra_data = Yoti::Protobuf::Sharepubapi::ExtraData.new
@@ -16,6 +17,12 @@ def create_extra_data_proto(*rows)
 end
 
 describe 'Yoti::Share::ExtraData' do
+  let :token do
+    'tokenValue1'
+  end
+  let :b64token do
+    Base64.urlsafe_encode64(token, padding: false)
+  end
   let :now do
     DateTime.now
   end
@@ -34,18 +41,12 @@ describe 'Yoti::Share::ExtraData' do
   end
 
   context 'with two third party attributes' do
-    let :token_value do
-      'tokenValue1'
-    end
-    let :b64token do
-      Base64.strict_encode64 token_value
-    end
     let :attribute_name do
       'attributeName1'
     end
     let :proto do
       create_extra_data_proto(
-        [token_value, now, attribute_name],
+        [token, now, attribute_name],
         ['tokenValue2', now, 'attributeName2']
       )
     end
@@ -67,12 +68,6 @@ describe 'Yoti::Share::ExtraData' do
   end
 
   context 'with multiple issuing attributes' do
-    let :token_value do
-      'tokenValue'
-    end
-    let :b64token do
-      Base64.strict_encode64 token_value
-    end
     let :attribute1 do
       'attribute1'
     end
@@ -81,7 +76,7 @@ describe 'Yoti::Share::ExtraData' do
     end
     let :proto do
       create_extra_data_proto(
-        [token_value, now, attribute1, attribute2]
+        [token, now, attribute1, attribute2]
       )
     end
     let :extra_data do
@@ -103,12 +98,6 @@ describe 'Yoti::Share::ExtraData' do
   end
 
   context 'with no expiry date' do
-    let :token do
-      'tokenValue'
-    end
-    let :b64token do
-      Base64.strict_encode64 token
-    end
     let :attribute do
       'attributeName'
     end
@@ -135,12 +124,6 @@ describe 'Yoti::Share::ExtraData' do
   end
 
   context 'with no issuing attributes' do
-    let :token do
-      'tokenValue'
-    end
-    let :b64token do
-      Base64.strict_encode64 token
-    end
     let :proto do
       create_extra_data_proto(
         [token, now]


### PR DESCRIPTION
> Version: `1.8.1`

### Fixed
- Attribute Issuance token is now base64 URL encoded