### PR TITLE
SDK-1810: Support media responses with no content 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'guard'
 gem 'guard-rspec'
-gem 'rubocop'
+gem 'rubocop', '~> 0.93.1', require: false
 gem 'rubocop-performance'
 
 gemspec

--- a/examples/doc_scan/app/controllers/yoti_controller.rb
+++ b/examples/doc_scan/app/controllers/yoti_controller.rb
@@ -64,12 +64,6 @@ class YotiController < ApplicationController
                    .with_required_document(
                      Yoti::DocScan::Session::Create::RequiredIdDocument
                      .builder
-                     .with_filter(
-                       Yoti::DocScan::Session::Create::OrthogonalRestrictionsFilter
-                       .builder
-                       .with_included_document_types(['DRIVING_LICENCE'])
-                       .build
-                     )
                      .build
                    )
                    .build
@@ -98,7 +92,11 @@ class YotiController < ApplicationController
 
     media = Yoti::DocScan::Client.get_media_content(session[:DOC_SCAN_SESSION_ID], media_id)
 
-    render body: media.content, content_type: media.mime_type
+    if media.nil?
+      head :no_content
+    else
+      render body: media.content, content_type: media.mime_type
+    end
   end
 
   #

--- a/lib/yoti/doc_scan/client.rb
+++ b/lib/yoti/doc_scan/client.rb
@@ -84,7 +84,7 @@ module Yoti
         # @param [String] session_id
         # @param [String] media_id
         #
-        # @return [Yoti::Media]
+        # @return [Yoti::Media|nil]
         #
         def get_media_content(session_id, media_id)
           Validation.assert_is_a(String, session_id, 'session_id')
@@ -99,9 +99,13 @@ module Yoti
           begin
             response = request.execute
 
+            content_type = response.get_fields('content-type')
+
+            return nil if response.code == 204 || content_type.nil?
+
             Yoti::Media.new(
               response.body,
-              response.get_fields('content-type')[0]
+              content_type[0]
             )
           rescue Yoti::RequestError => e
             raise Yoti::DocScan::Error.wrap(e)

--- a/spec/yoti/doc_scan/client_spec.rb
+++ b/spec/yoti/doc_scan/client_spec.rb
@@ -8,7 +8,8 @@ def stub_doc_scan_api_request(
   response_body: '{}',
   status: 200,
   request_body: nil,
-  query: nil
+  query: nil,
+  headers: { 'Content-Type' => 'application/json' }
 )
   stub = stub_request(method, %r{https:\/\/api.yoti.com\/idverify\/v1\/#{endpoint}})
   stub.with(body: request_body) unless request_body.nil?
@@ -16,7 +17,7 @@ def stub_doc_scan_api_request(
   stub.to_return(
     status: status,
     body: response_body,
-    headers: { 'Content-Type' => 'application/json' }
+    headers: headers
   )
 end
 
@@ -165,6 +166,23 @@ describe 'Yoti::DocScan::Client' do
         expect(media).to be_a(Yoti::Media)
         expect(media.content).to be('{}')
         expect(media.mime_type).to be('application/json')
+      end
+    end
+
+    context 'when response has no content' do
+      before(:context) do
+        stub_doc_scan_api_request(
+          method: :get,
+          status: 204,
+          headers: {},
+          endpoint: 'sessions/some-id/media/some-media-id/content'
+        )
+      end
+
+      it 'returns nil' do
+        media = Yoti::DocScan::Client.get_media_content('some-id', 'some-media-id')
+
+        expect(media).to be_nil
       end
     end
 


### PR DESCRIPTION
### Fixed
- `204` media responses now return `nil`

Also pinned Rubocop to `0.93` (prevent updating to `1.1` which will be done in a separate PR)